### PR TITLE
Change variable name for iterated opening hours

### DIFF
--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -53,8 +53,8 @@ class OpeningHours
     {
         list($openingHours, $exceptions) = $this->parseOpeningHoursAndExceptions($data);
 
-        foreach ($openingHours as $day => $openingHours) {
-            $this->setOpeningHoursFromStrings($day, $openingHours);
+        foreach ($openingHours as $day => $openingHoursForThisDay) {
+            $this->setOpeningHoursFromStrings($day, $openingHoursForThisDay);
         }
 
         $this->setExceptionsFromStrings($exceptions);


### PR DESCRIPTION
`$openingHours` was used as iterated and iterating variable.

:octocat: