### PR TITLE
Next Open Hours feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ $openingHours->forDate(new DateTime('2016-12-25'));
 $openingHours->exceptions();
 ```
 
+It can also return next open `DateTime` from the given `DateTime`.
+
+```
+// 2016-12-26 09:00:00
+$nextOpen = $openingHours->nextOpen(new DateTime('2016-12-25 10:00:00'));
+
+// 2016-12-24 13:00:00
+$nextOpen = $openingHours->nextOpen(new DateTime('2016-12-24 11:00:00'));
+```
 Read the usage section for the full api.
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
@@ -192,6 +201,14 @@ Checks if the business is closed right now.
 
 ```php
 $openingHours->isClosed();
+```
+
+#### `nextOpen(DateTimeInterface $dateTime) : DateTime`
+
+Returns next open DateTime from the given DateTime
+
+```php
+$openingHours->nextOpen(new DateTime('2016-12-24 11:00:00'));
 ```
 
 ### `Spatie\OpeningHours\OpeningHoursForDay`

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -117,6 +117,28 @@ class OpeningHours
         return $this->isClosedAt(new DateTime());
     }
 
+    public function nextOpen(DateTimeInterface $dateTime) : DateTime
+    {
+        $openingHoursForDay = $this->forDate($dateTime);
+        $nextOpen = $openingHoursForDay->nextOpen(Time::fromDateTime($dateTime));
+
+        while ($nextOpen == false) {
+            $dateTime
+                ->modify('+1 day')
+                ->setTime(0, 0, 0)
+            ;
+
+            $openingHoursForDay = $this->forDate($dateTime);
+
+            $nextOpen = $openingHoursForDay->nextOpen(Time::fromDateTime($dateTime));
+        }
+
+        $nextDateTime = $nextOpen->toDateTime();
+        $dateTime->setTime($nextDateTime->format('G'), $nextDateTime->format('i'), 0);
+
+        return $dateTime;
+    }
+
     protected function parseOpeningHoursAndExceptions(array $data): array
     {
         $exceptions = Arr::pull($data, 'exceptions', []);

--- a/src/OpeningHoursForDay.php
+++ b/src/OpeningHoursForDay.php
@@ -40,6 +40,42 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
         return false;
     }
 
+    public function nextOpen(Time $time)
+    {
+        foreach ($this->openingHours as $timeRange) {
+            if ($nextOpen = $this->findNextOpenInWorkingHours($time, $timeRange)) {
+                return $nextOpen;
+            }
+
+            if ($nextOpen = $this->findNextOpenInFreeTime($time, $timeRange)) {
+                return $nextOpen;
+            }
+        }
+
+        return false;
+    }
+
+    private function findNextOpenInWorkingHours(Time $time, TimeRange $timeRange)
+    {
+        if ($timeRange->containsTime($time) && next($timeRange) !== $timeRange) {
+            return next($timeRange);
+        }
+    }
+
+    private function findNextOpenInFreeTime(Time $time, TimeRange $timeRange, TimeRange &$prevTimeRange = null)
+    {
+        $timeOffRange = $prevTimeRange ?
+            TimeRange::fromString($prevTimeRange->end().'-'.$timeRange->start()) :
+            TimeRange::fromString('00:00-'.$timeRange->start())
+        ;
+
+        if ($timeOffRange->containsTime($time)) {
+            return $timeRange->start();
+        }
+
+        $prevTimeRange = $timeRange;
+    }
+
     public function offsetExists($offset): bool
     {
         return isset($this->openingHours[$offset]);

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\OpeningHours\Test;
 
 use DateTime;
+use Spatie\OpeningHours\Time;
 use Spatie\OpeningHours\OpeningHours;
 
 class OpeningHoursTest extends \PHPUnit_Framework_TestCase
@@ -124,5 +125,49 @@ class OpeningHoursTest extends \PHPUnit_Framework_TestCase
         $shouldBeClosed = new DateTime('2016-09-26 11:00:00');
         $this->assertFalse($openingHours->isOpenAt($shouldBeClosed));
         $this->assertTrue($openingHours->isClosedAt($shouldBeClosed));
+    }
+
+    /** @test */
+    public function it_can_determine_next_open_hours_from_non_working_date_time()
+    {
+        $openingHours = OpeningHours::create([
+            'monday' => ['09:00-11:00', '13:00-19:00'],
+        ]);
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2016-09-26 12:00:00'));
+
+        $this->assertInstanceOf('\DateTime', $nextTimeOpen);
+        $this->assertEquals('2016-09-26 13:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+    }
+
+    /** @test */
+    public function it_can_determine_next_open_hours_from_working_date_time()
+    {
+        $openingHours = OpeningHours::create([
+            'monday' => ['09:00-11:00', '13:00-19:00'],
+            'tuesday' => ['10:00-11:00', '14:00-19:00'],
+        ]);
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2016-09-26 16:00:00'));
+
+        $this->assertInstanceOf('\DateTime', $nextTimeOpen);
+        $this->assertEquals('2016-09-27 10:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+    }
+
+    /** @test */
+    public function it_can_determine_next_open_hours_from_early_morning()
+    {
+        $openingHours = OpeningHours::create([
+            'monday' => ['09:00-11:00', '13:00-19:00'],
+            'tuesday' => ['10:00-11:00', '14:00-19:00'],
+            'exceptions' => [
+                '2016-09-26' => [],
+            ],
+        ]);
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2016-09-26 04:00:00'));
+
+        $this->assertInstanceOf('\DateTime', $nextTimeOpen);
+        $this->assertEquals('2016-09-27 10:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
     }
 }


### PR DESCRIPTION
Added feature to get next open hour for DateTime requested in #18 

Example:

```
    $openingHours = OpeningHours::create([
        'monday' => ['09:00-11:00', '13:00-19:00'],
    ]);

    // 2016-09-26 13:00:00
    $nextTimeOpen = $openingHours->nextOpen(new DateTime('2016-09-26 12:00:00'));
```

Unit tests added for class `OpeningHours` but not for `OpeningHoursForDay` because it is also covered in the same tests.

There could be space for code improvement in method `nextOpen`, and I would like to improve it if you have some ideas.

New method `nextOpen` is documented and unit tested. Also, psr2 fixer is applied to the code changes.
