### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*"
+        "phpunit/phpunit": "^6.4"
     },
     "autoload": {
         "psr-4": {

--- a/tests/OpeningHoursFillTest.php
+++ b/tests/OpeningHoursFillTest.php
@@ -4,12 +4,13 @@ namespace Spatie\OpeningHours\Test;
 
 use DateTime;
 use Spatie\OpeningHours\Day;
+use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\TimeRange;
 use Spatie\OpeningHours\OpeningHours;
 use Spatie\OpeningHours\Exceptions\InvalidDate;
 use Spatie\OpeningHours\Exceptions\InvalidDayName;
 
-class OpeningHoursFillTest extends \PHPUnit_Framework_TestCase
+class OpeningHoursFillTest extends TestCase
 {
     /** @test */
     public function it_fills_opening_hours()

--- a/tests/OpeningHoursForDayTest.php
+++ b/tests/OpeningHoursForDayTest.php
@@ -3,12 +3,12 @@
 namespace Spatie\OpeningHours\Test;
 
 use Spatie\OpeningHours\Time;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\TimeRange;
 use Spatie\OpeningHours\OpeningHoursForDay;
 use Spatie\OpeningHours\Exceptions\OverlappingTimeRanges;
 
-class OpeningHoursForDayTest extends PHPUnit_Framework_TestCase
+class OpeningHoursForDayTest extends TestCase
 {
     /** @test */
     public function it_can_be_created_from_an_array_of_time_range_strings()

--- a/tests/OpeningHoursStructuredDataTest.php
+++ b/tests/OpeningHoursStructuredDataTest.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\OpeningHours\Test;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\OpeningHours;
 
-class OpeningHoursStructuredDataTest extends PHPUnit_Framework_TestCase
+class OpeningHoursStructuredDataTest extends TestCase
 {
     /** @test */
     public function it_can_render_opening_hours_as_an_array_of_structured_data()

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -4,9 +4,10 @@ namespace Spatie\OpeningHours\Test;
 
 use DateTime;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\OpeningHours;
 
-class OpeningHoursTest extends \PHPUnit_Framework_TestCase
+class OpeningHoursTest extends TestCase
 {
     /** @test */
     public function it_can_return_the_opening_hours_for_a_regular_week()

--- a/tests/TimeRangeTest.php
+++ b/tests/TimeRangeTest.php
@@ -3,11 +3,11 @@
 namespace Spatie\OpeningHours\Test;
 
 use Spatie\OpeningHours\Time;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\TimeRange;
 use Spatie\OpeningHours\Exceptions\InvalidTimeRangeString;
 
-class TimeRangeTest extends PHPUnit_Framework_TestCase
+class TimeRangeTest extends TestCase
 {
     /** @test */
     public function it_can_be_created_from_a_string()

--- a/tests/TimeTest.php
+++ b/tests/TimeTest.php
@@ -4,10 +4,10 @@ namespace Spatie\OpeningHours\Test;
 
 use DateTime;
 use Spatie\OpeningHours\Time;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\Exceptions\InvalidTimeString;
 
-class TimeTest extends PHPUnit_Framework_TestCase
+class TimeTest extends TestCase
 {
     /** @test */
     public function it_can_be_created_from_a_string()


### PR DESCRIPTION
As we support `PHP 7`, I've updated our suite of tests to `PHPUnit 6`.

PS: I won't apply [this](https://styleci.io/analyses/qM9kYM) `StyleCI` changes. There are not related to this PR :sweat_smile: 