### PR TITLE
Return combined OpeningHoursForDay

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ $openingHours->forDay('monday');
 // OpeningHoursForDay[] for the regular schedule, keyed by day name
 $openingHours->forWeek();
 
+// Array of day with same schedule for the regular schedule, keyed by day name, days combined by working hours
+$openingHours->forWeekCombined();
+
 // OpeningHoursForDay object for a specific day
 $openingHours->forDate(new DateTime('2016-12-25'));
 
@@ -123,6 +126,14 @@ Returns an array of `OpeningHoursForDay` objects for a regular week.
 
 ```php
 $openingHours->forWeek();
+```
+
+#### `OpeningHours::forWeekCombined(): array`
+
+Returns an array of days. Array key is first day with same hours, array values are days that have the same working hours and `OpeningHoursForDay` object. 
+
+```php
+$openingHours->forWeekCombined();
 ```
 
 #### `OpeningHours::forDay(string $day): Spatie\OpeningHours\OpeningHoursForDay`

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -81,14 +81,11 @@ class OpeningHours
         $uniqueOpeningHours = array_unique($allOpeningHours);
         $nonUniqueOpeningHours = $allOpeningHours;
 
-        // Initialize $equalDays array based on unique days
         foreach ($uniqueOpeningHours as $day => $value) {
             $equalDays[$day] = ['days' => [$day], 'opening_hours' => $value];
             unset($nonUniqueOpeningHours[$day]);
         }
 
-        // Compare each uniqueDay data, with data from nonUnique days.
-        // Populate equalDays array if data matches
         foreach ($uniqueOpeningHours as $uniqueDay => $uniqueValue) {
             /** @var OpeningHoursForDay $nonUniqueValue */
             foreach ($nonUniqueOpeningHours as $nonUniqueDay => $nonUniqueValue) {

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -87,16 +87,12 @@ class OpeningHours
             unset($nonUniqueOpeningHours[$day]);
         }
 
-        /**
-         * @var OpeningHoursForDay $uniqueValue
-         *
-         * Compare each uniqueDay data, with data from nonUnique days.
-         * Populate equalDays array if data matches
-         */
+        // Compare each uniqueDay data, with data from nonUnique days.
+        // Populate equalDays array if data matches
         foreach ($uniqueOpeningHours as $uniqueDay => $uniqueValue) {
             /** @var OpeningHoursForDay $nonUniqueValue */
             foreach ($nonUniqueOpeningHours as $nonUniqueDay => $nonUniqueValue) {
-                if((string) $uniqueValue === (string) $nonUniqueValue){
+                if ((string) $uniqueValue === (string) $nonUniqueValue) {
                     $equalDays[$uniqueDay]['days'][] = $nonUniqueDay;
                 }
             }

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -74,6 +74,37 @@ class OpeningHours
         return $this->openingHours;
     }
 
+    public function forWeekCombined(): array
+    {
+        $equalDays = [];
+        $allOpeningHours = $this->openingHours;
+        $uniqueOpeningHours = array_unique($allOpeningHours);
+        $nonUniqueOpeningHours = $allOpeningHours;
+
+        // Initialize $equalDays array based on unique days
+        foreach ($uniqueOpeningHours as $day => $value) {
+            $equalDays[$day] = ['days' => [$day], 'opening_hours' => $value];
+            unset($nonUniqueOpeningHours[$day]);
+        }
+
+        /**
+         * @var OpeningHoursForDay $uniqueValue
+         *
+         * Compare each uniqueDay data, with data from nonUnique days.
+         * Populate equalDays array if data matches
+         */
+        foreach ($uniqueOpeningHours as $uniqueDay => $uniqueValue) {
+            /** @var OpeningHoursForDay $nonUniqueValue */
+            foreach ($nonUniqueOpeningHours as $nonUniqueDay => $nonUniqueValue) {
+                if((string) $uniqueValue === (string) $nonUniqueValue){
+                    $equalDays[$uniqueDay]['days'][] = $nonUniqueDay;
+                }
+            }
+        }
+
+        return $equalDays;
+    }
+
     public function forDay(string $day): OpeningHoursForDay
     {
         $day = $this->normalizeDayName($day);

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -87,7 +87,6 @@ class OpeningHours
         }
 
         foreach ($uniqueOpeningHours as $uniqueDay => $uniqueValue) {
-            /** @var OpeningHoursForDay $nonUniqueValue */
             foreach ($nonUniqueOpeningHours as $nonUniqueDay => $nonUniqueValue) {
                 if ((string) $uniqueValue === (string) $nonUniqueValue) {
                     $equalDays[$uniqueDay]['days'][] = $nonUniqueDay;

--- a/src/OpeningHoursForDay.php
+++ b/src/OpeningHoursForDay.php
@@ -123,4 +123,14 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
             }
         }
     }
+
+    public function __toString()
+    {
+        $values = [];
+        foreach ($this->openingHours as $openingHour) {
+            $values[] = (string) $openingHour;
+        }
+
+        return implode(',', $values);
+    }
 }

--- a/tests/OpeningHoursForDayTest.php
+++ b/tests/OpeningHoursForDayTest.php
@@ -41,4 +41,12 @@ class OpeningHoursForDayTest extends TestCase
         $this->assertFalse($openingHoursForDay->isOpenAt(Time::fromString('08:00')));
         $this->assertFalse($openingHoursForDay->isOpenAt(Time::fromString('18:00')));
     }
+
+    /** @test */
+    public function it_casts_to_string()
+    {
+        $openingHoursForDay = OpeningHoursForDay::fromStrings(['09:00-12:00', '13:00-18:00']);
+
+        $this->assertEquals('09:00-12:00,13:00-18:00', (string) $openingHoursForDay);
+    }
 }

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -36,7 +36,7 @@ class OpeningHoursTest extends TestCase
             'tuesday' => ['09:00-18:00'],
             'wednesday' => ['11:00-15:00'],
             'thursday' => ['11:00-15:00'],
-            'friday' => ['12:00-14:00']
+            'friday' => ['12:00-14:00'],
         ]);
 
         $openingHoursForWeek = $openingHours->forWeekCombined();
@@ -44,7 +44,6 @@ class OpeningHoursTest extends TestCase
         $this->assertCount(4, $openingHoursForWeek);
         $this->assertEquals('11:00-15:00', $openingHoursForWeek['wednesday']['opening_hours']);
         $this->assertEquals('thursday', array_values($openingHoursForWeek['wednesday']['days'])[1]);
-
     }
 
     /** @test */

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -29,6 +29,25 @@ class OpeningHoursTest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_combined_opening_hours_for_a_regular_week()
+    {
+        $openingHours = OpeningHours::create([
+            'monday' => ['09:00-18:00'],
+            'tuesday' => ['09:00-18:00'],
+            'wednesday' => ['11:00-15:00'],
+            'thursday' => ['11:00-15:00'],
+            'friday' => ['12:00-14:00']
+        ]);
+
+        $openingHoursForWeek = $openingHours->forWeekCombined();
+
+        $this->assertCount(4, $openingHoursForWeek);
+        $this->assertEquals('11:00-15:00', $openingHoursForWeek['wednesday']['opening_hours']);
+        $this->assertEquals('thursday', array_values($openingHoursForWeek['wednesday']['days'])[1]);
+
+    }
+
+    /** @test */
     public function it_can_validate_the_opening_hours()
     {
         $valid = OpeningHours::isValid([


### PR DESCRIPTION
Hi!

This PR adds `forWeekCombined()` in OpeningHours.
Function returns array, where key is the first day that has similar hours, with an array of values, where `days[]` are all days where timings are the same, and `opening_hours` is the `OpeningHoursForDay` object. 

- [x] Tests provided
- [x] No BC breaks
- [x] Will update README if maintainers are good with the PR



Thank you!

Kind regards,
Deniss 