### PR TITLE
Made PHP 5.6 compatible / Added OSM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,29 @@
-build
+# phpstorm project files
+.idea
+*.iml
+
+# netbeans project files
+nbproject
+
+# zend studio for eclipse project files
+.buildpath
+.project
+.settings
+
+# windows thumbnail cache
+Thumbs.db
+
+# composer vendor dir
+/vendor
+
+# composer itself is not needed and related files
+composer.phar
 composer.lock
-docs
-vendor
+
+# Mac DS_Store Files
+.DS_Store
+
+# phpunit itself is not needed
+phpunit.phar
+# local phpunit config
+/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "*"
     },
     "autoload": {
         "psr-4": {
@@ -39,5 +39,5 @@
     },
     "config": {
         "sort-packages": true
-  }
+    }
 }

--- a/src/Day.php
+++ b/src/Day.php
@@ -9,7 +9,8 @@ use Spatie\OpeningHours\Helpers\Arr;
  * Class Day
  * @package Spatie\OpeningHours
  */
-class Day {
+class Day
+{
     const MONDAY = 'monday';
     const TUESDAY = 'tuesday';
     const WEDNESDAY = 'wednesday';
@@ -19,9 +20,19 @@ class Day {
     const SUNDAY = 'sunday';
 
     /**
+     * @param callable $callback
      * @return array
      */
-    public static function days() {
+    public static function mapDays(callable $callback)
+    {
+        return Arr::map(Arr::mirror(static::days()), $callback);
+    }
+
+    /**
+     * @return array
+     */
+    public static function days()
+    {
         return [
             static::MONDAY,
             static::TUESDAY,
@@ -34,18 +45,11 @@ class Day {
     }
 
     /**
-     * @param callable $callback
-     * @return array
-     */
-    public static function mapDays(callable $callback) {
-        return Arr::map(Arr::mirror(static::days()), $callback);
-    }
-
-    /**
      * @param string $day
      * @return bool
      */
-    public static function isValid($day) {
+    public static function isValid($day)
+    {
         return in_array($day, static::days());
     }
 
@@ -53,7 +57,8 @@ class Day {
      * @param DateTimeInterface $dateTime
      * @return string
      */
-    public static function onDateTime(DateTimeInterface $dateTime) {
+    public static function onDateTime(DateTimeInterface $dateTime)
+    {
         return static::days()[$dateTime->format('N') - 1];
     }
 
@@ -61,7 +66,8 @@ class Day {
      * @param string $day
      * @return int
      */
-    public static function toISO($day) {
+    public static function toISO($day)
+    {
         return array_search($day, static::days()) + 1;
     }
 }

--- a/src/Day.php
+++ b/src/Day.php
@@ -5,8 +5,11 @@ namespace Spatie\OpeningHours;
 use DateTimeInterface;
 use Spatie\OpeningHours\Helpers\Arr;
 
-class Day
-{
+/**
+ * Class Day
+ * @package Spatie\OpeningHours
+ */
+class Day {
     const MONDAY = 'monday';
     const TUESDAY = 'tuesday';
     const WEDNESDAY = 'wednesday';
@@ -15,8 +18,10 @@ class Day
     const SATURDAY = 'saturday';
     const SUNDAY = 'sunday';
 
-    public static function days(): array
-    {
+    /**
+     * @return array
+     */
+    public static function days() {
         return [
             static::MONDAY,
             static::TUESDAY,
@@ -28,23 +33,35 @@ class Day
         ];
     }
 
-    public static function mapDays(callable $callback): array
-    {
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public static function mapDays(callable $callback) {
         return Arr::map(Arr::mirror(static::days()), $callback);
     }
 
-    public static function isValid(string $day): bool
-    {
+    /**
+     * @param string $day
+     * @return bool
+     */
+    public static function isValid($day) {
         return in_array($day, static::days());
     }
 
-    public static function onDateTime(DateTimeInterface $dateTime): string
-    {
+    /**
+     * @param DateTimeInterface $dateTime
+     * @return string
+     */
+    public static function onDateTime(DateTimeInterface $dateTime) {
         return static::days()[$dateTime->format('N') - 1];
     }
 
-    public static function toISO(string $day): int
-    {
+    /**
+     * @param string $day
+     * @return int
+     */
+    public static function toISO($day) {
         return array_search($day, static::days()) + 1;
     }
 }

--- a/src/Exceptions/InvalidDate.php
+++ b/src/Exceptions/InvalidDate.php
@@ -2,10 +2,12 @@
 
 namespace Spatie\OpeningHours\Exceptions;
 
-class InvalidDate extends Exception
-{
-    public static function invalidDate(string $date): self
-    {
+class InvalidDate extends Exception {
+    /**
+     * @param string $date
+     * @return InvalidDate
+     */
+    public static function invalidDate($date) {
         return new self("Date `{$date}` isn't a valid date. Dates should be formatted as Y-m-d, e.g. `2016-12-25`.");
     }
 }

--- a/src/Exceptions/InvalidDate.php
+++ b/src/Exceptions/InvalidDate.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\OpeningHours\Exceptions;
 
-class InvalidDate extends Exception {
+class InvalidDate extends Exception
+{
     /**
      * @param string $date
      * @return InvalidDate
      */
-    public static function invalidDate($date) {
+    public static function invalidDate($date)
+    {
         return new self("Date `{$date}` isn't a valid date. Dates should be formatted as Y-m-d, e.g. `2016-12-25`.");
     }
 }

--- a/src/Exceptions/InvalidDayName.php
+++ b/src/Exceptions/InvalidDayName.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\OpeningHours\Exceptions;
 
-class InvalidDayName extends Exception {
+class InvalidDayName extends Exception
+{
     /**
      * @param string $name
      * @return InvalidDayName
      */
-    public static function invalidDayName($name) {
+    public static function invalidDayName($name)
+    {
         return new self("Day `{$name}` isn't a valid day name. Valid day names are lowercase english words, e.g. `monday`, `thursday`.");
     }
 }

--- a/src/Exceptions/InvalidDayName.php
+++ b/src/Exceptions/InvalidDayName.php
@@ -2,10 +2,12 @@
 
 namespace Spatie\OpeningHours\Exceptions;
 
-class InvalidDayName extends Exception
-{
-    public static function invalidDayName(string $name): self
-    {
+class InvalidDayName extends Exception {
+    /**
+     * @param string $name
+     * @return InvalidDayName
+     */
+    public static function invalidDayName($name) {
         return new self("Day `{$name}` isn't a valid day name. Valid day names are lowercase english words, e.g. `monday`, `thursday`.");
     }
 }

--- a/src/Exceptions/InvalidTimeRangeString.php
+++ b/src/Exceptions/InvalidTimeRangeString.php
@@ -2,10 +2,12 @@
 
 namespace Spatie\OpeningHours\Exceptions;
 
-class InvalidTimeRangeString extends Exception
-{
-    public static function forString(string $string): self
-    {
+class InvalidTimeRangeString extends Exception {
+    /**
+     * @param string $string
+     * @return InvalidTimeRangeString
+     */
+    public static function forString($string) {
         return new self("The string `{$string}` isn't a valid time range string. A time string must be a formatted as `H:i-H:i`, e.g. `09:00-18:00`.");
     }
 }

--- a/src/Exceptions/InvalidTimeRangeString.php
+++ b/src/Exceptions/InvalidTimeRangeString.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\OpeningHours\Exceptions;
 
-class InvalidTimeRangeString extends Exception {
+class InvalidTimeRangeString extends Exception
+{
     /**
      * @param string $string
      * @return InvalidTimeRangeString
      */
-    public static function forString($string) {
+    public static function forString($string)
+    {
         return new self("The string `{$string}` isn't a valid time range string. A time string must be a formatted as `H:i-H:i`, e.g. `09:00-18:00`.");
     }
 }

--- a/src/Exceptions/InvalidTimeString.php
+++ b/src/Exceptions/InvalidTimeString.php
@@ -2,12 +2,14 @@
 
 namespace Spatie\OpeningHours\Exceptions;
 
-class InvalidTimeString extends Exception {
+class InvalidTimeString extends Exception
+{
     /**
      * @param string $string
      * @return InvalidTimeString
      */
-    public static function forString($string) {
+    public static function forString($string)
+    {
         return new self("The string `{$string}` isn't a valid time string. A time string must be a formatted as `H:i`, e.g. `06:00`, `18:00`.");
     }
 }

--- a/src/Exceptions/InvalidTimeString.php
+++ b/src/Exceptions/InvalidTimeString.php
@@ -2,10 +2,12 @@
 
 namespace Spatie\OpeningHours\Exceptions;
 
-class InvalidTimeString extends Exception
-{
-    public static function forString(string $string): self
-    {
+class InvalidTimeString extends Exception {
+    /**
+     * @param string $string
+     * @return InvalidTimeString
+     */
+    public static function forString($string) {
         return new self("The string `{$string}` isn't a valid time string. A time string must be a formatted as `H:i`, e.g. `06:00`, `18:00`.");
     }
 }

--- a/src/Exceptions/NotSupportedException.php
+++ b/src/Exceptions/NotSupportedException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @package opening-hours
+ * @author Simon Karlen <simi.albi@gmail.com>
+ */
+
+namespace Spatie\OpeningHours\Exceptions;
+
+
+class NotSupportedException extends Exception {
+    /**
+     * @param string $feature
+     * @return NotSupportedException
+     */
+    public static function notSupported($feature) {
+        return new self("Unsupported `{$feature}`.");
+    }
+}

--- a/src/Exceptions/NotSupportedException.php
+++ b/src/Exceptions/NotSupportedException.php
@@ -7,12 +7,14 @@
 namespace Spatie\OpeningHours\Exceptions;
 
 
-class NotSupportedException extends Exception {
+class NotSupportedException extends Exception
+{
     /**
      * @param string $feature
      * @return NotSupportedException
      */
-    public static function notSupported($feature) {
+    public static function notSupported($feature)
+    {
         return new self("Unsupported `{$feature}`.");
     }
 }

--- a/src/Exceptions/OverlappingTimeRanges.php
+++ b/src/Exceptions/OverlappingTimeRanges.php
@@ -2,13 +2,15 @@
 
 namespace Spatie\OpeningHours\Exceptions;
 
-class OverlappingTimeRanges extends Exception {
+class OverlappingTimeRanges extends Exception
+{
     /**
      * @param string $rangeA
      * @param string $rangeB
      * @return OverlappingTimeRanges
      */
-    public static function forRanges($rangeA, $rangeB) {
+    public static function forRanges($rangeA, $rangeB)
+    {
         return new self("Time ranges {$rangeA} and {$rangeB} overlap.");
     }
 }

--- a/src/Exceptions/OverlappingTimeRanges.php
+++ b/src/Exceptions/OverlappingTimeRanges.php
@@ -2,10 +2,13 @@
 
 namespace Spatie\OpeningHours\Exceptions;
 
-class OverlappingTimeRanges extends Exception
-{
-    public static function forRanges(string $rangeA, string $rangeB): self
-    {
+class OverlappingTimeRanges extends Exception {
+    /**
+     * @param string $rangeA
+     * @param string $rangeB
+     * @return OverlappingTimeRanges
+     */
+    public static function forRanges($rangeA, $rangeB) {
         return new self("Time ranges {$rangeA} and {$rangeB} overlap.");
     }
 }

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -2,15 +2,26 @@
 
 namespace Spatie\OpeningHours\Helpers;
 
-class Arr
-{
-    public static function filter(array $array, callable $callback): array
-    {
+/**
+ * Class Arr
+ * @package Spatie\OpeningHours\Helpers
+ */
+class Arr {
+    /**
+     * @param array $array
+     * @param callable $callback
+     * @return array
+     */
+    public static function filter(array $array, callable $callback) {
         return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
     }
 
-    public static function map(array $array, callable $callback): array
-    {
+    /**
+     * @param array $array
+     * @param callable $callback
+     * @return array
+     */
+    public static function map(array $array, callable $callback) {
         $keys = array_keys($array);
 
         $items = array_map($callback, $array, $keys);
@@ -18,8 +29,12 @@ class Arr
         return array_combine($keys, $items);
     }
 
-    public static function flatMap(array $array, callable $callback): array
-    {
+    /**
+     * @param array $array
+     * @param callable $callback
+     * @return array
+     */
+    public static function flatMap(array $array, callable $callback) {
         $mapped = self::map($array, $callback);
 
         $flattened = [];
@@ -35,22 +50,33 @@ class Arr
         return $flattened;
     }
 
-    public static function pull(&$array, $key, $default = null)
-    {
-        $value = $array[$key] ?? $default;
+    /**
+     * @param array $array
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public static function pull(array &$array, $key, $default = null) {
+        $value = isset($array[$key]) ? $array[$key] : $default;
 
         unset($array[$key]);
 
         return $value;
     }
 
-    public static function mirror(array $array): array
-    {
+    /**
+     * @param array $array
+     * @return array
+     */
+    public static function mirror(array $array) {
         return array_combine($array, $array);
     }
 
-    public static function createUniquePairs(array $array): array
-    {
+    /**
+     * @param array $array
+     * @return array
+     */
+    public static function createUniquePairs(array $array) {
         $pairs = [];
 
         while ($a = array_shift($array)) {

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -6,13 +6,15 @@ namespace Spatie\OpeningHours\Helpers;
  * Class Arr
  * @package Spatie\OpeningHours\Helpers
  */
-class Arr {
+class Arr
+{
     /**
      * @param array $array
      * @param callable $callback
      * @return array
      */
-    public static function filter(array $array, callable $callback) {
+    public static function filter(array $array, callable $callback)
+    {
         return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
     }
 
@@ -21,20 +23,8 @@ class Arr {
      * @param callable $callback
      * @return array
      */
-    public static function map(array $array, callable $callback) {
-        $keys = array_keys($array);
-
-        $items = array_map($callback, $array, $keys);
-
-        return array_combine($keys, $items);
-    }
-
-    /**
-     * @param array $array
-     * @param callable $callback
-     * @return array
-     */
-    public static function flatMap(array $array, callable $callback) {
+    public static function flatMap(array $array, callable $callback)
+    {
         $mapped = self::map($array, $callback);
 
         $flattened = [];
@@ -52,11 +42,26 @@ class Arr {
 
     /**
      * @param array $array
+     * @param callable $callback
+     * @return array
+     */
+    public static function map(array $array, callable $callback)
+    {
+        $keys = array_keys($array);
+
+        $items = array_map($callback, $array, $keys);
+
+        return array_combine($keys, $items);
+    }
+
+    /**
+     * @param array $array
      * @param string $key
      * @param mixed $default
      * @return mixed
      */
-    public static function pull(array &$array, $key, $default = null) {
+    public static function pull(array &$array, $key, $default = null)
+    {
         $value = isset($array[$key]) ? $array[$key] : $default;
 
         unset($array[$key]);
@@ -68,7 +73,8 @@ class Arr {
      * @param array $array
      * @return array
      */
-    public static function mirror(array $array) {
+    public static function mirror(array $array)
+    {
         return array_combine($array, $array);
     }
 
@@ -76,7 +82,8 @@ class Arr {
      * @param array $array
      * @return array
      */
-    public static function createUniquePairs(array $array) {
+    public static function createUniquePairs(array $array)
+    {
         $pairs = [];
 
         while ($a = array_shift($array)) {

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -11,13 +11,8 @@ use Spatie\OpeningHours\Exceptions\InvalidDayName;
 use Spatie\OpeningHours\Exceptions\NotSupportedException;
 use Spatie\OpeningHours\Helpers\Arr;
 
-class OpeningHours {
-    /** @var \Spatie\OpeningHours\Day[] */
-    protected $openingHours = [];
-    /** @var array */
-    protected $exceptions = [];
-    /** @var DateTimeZone|null */
-    protected $timezone = null;
+class OpeningHours
+{
     const RGX_RULE_MODIFIER = '/^(open|closed|off)$/i';
     const RGX_WEEK_KEY = '/^week$/';
     const RGX_WEEK_VAL = '/^([01234]?[0-9]|5[0123])(-([01234]?[0-9]|5[0123]))?(,([01234]?[0-9]|5[0123])(-([01234]?[0-9]|5[0123]))?)*:?$/';
@@ -44,8 +39,15 @@ class OpeningHours {
         'November',
         'December'
     ];
+    /** @var \Spatie\OpeningHours\Day[] */
+    protected $openingHours = [];
+    /** @var array */
+    protected $exceptions = [];
+    /** @var DateTimeZone|null */
+    protected $timezone = null;
 
-    public function __construct($timezone = null) {
+    public function __construct($timezone = null)
+    {
         $this->timezone = $timezone ? new DateTimeZone($timezone) : null;
 
         $this->openingHours = Day::mapDays(function () {
@@ -54,24 +56,12 @@ class OpeningHours {
     }
 
     /**
-     * @param array|string $data
-     *
-     * @return static
-     */
-    public static function create($data) {
-        if (is_string($data)) {
-            return (new static())->fromOsmString($data);
-        }
-
-        return (new static())->fill($data);
-    }
-
-    /**
      * @param array $data
      *
      * @return bool
      */
-    public static function isValid(array $data) {
+    public static function isValid(array $data)
+    {
         try {
             static::create($data);
 
@@ -82,53 +72,68 @@ class OpeningHours {
     }
 
     /**
+     * @param array|string $data
+     *
+     * @return static
+     */
+    public static function create($data)
+    {
+        if (is_string($data)) {
+            return (new static())->fromOsmString($data);
+        }
+
+        return (new static())->fill($data);
+    }
+
+    /**
      * @param string $osmString
      * @return static
      * @throws NotSupportedException
      * @throws InvalidDate
      */
-    public static function fromOsmString($osmString) {
+    public static function fromOsmString($osmString)
+    {
         if ($osmString === '24/7') {
             return (new static())->fill([
-                'monday'    => ['00:00-24:00'],
-                'tuesday'   => ['00:00-24:00'],
+                'monday' => ['00:00-24:00'],
+                'tuesday' => ['00:00-24:00'],
                 'wednesday' => ['00:00-24:00'],
-                'thursday'  => ['00:00-24:00'],
-                'friday'    => ['00:00-24:00'],
-                'saturday'  => ['00:00-24:00'],
-                'sunday'    => ['00:00-24:00']
+                'thursday' => ['00:00-24:00'],
+                'friday' => ['00:00-24:00'],
+                'saturday' => ['00:00-24:00'],
+                'sunday' => ['00:00-24:00']
             ]);
         } elseif (preg_match('#([^\(]?sunrise.*[^\)-]+).*-.*([^\(]?sunset.*[^\)])#u', $osmString)) {
             $startTime = date_sunrise(time(), SUNFUNCS_RET_STRING);
-            $endTime   = date_sunrise(time(), SUNFUNCS_RET_STRING);
+            $endTime = date_sunrise(time(), SUNFUNCS_RET_STRING);
 
             return (new static())->fill([
-                'monday'    => [$startTime . '-' . $endTime],
-                'tuesday'   => [$startTime . '-' . $endTime],
+                'monday' => [$startTime . '-' . $endTime],
+                'tuesday' => [$startTime . '-' . $endTime],
                 'wednesday' => [$startTime . '-' . $endTime],
-                'thursday'  => [$startTime . '-' . $endTime],
-                'friday'    => [$startTime . '-' . $endTime],
-                'saturday'  => [$startTime . '-' . $endTime],
-                'sunday'    => [$startTime . '-' . $endTime]
+                'thursday' => [$startTime . '-' . $endTime],
+                'friday' => [$startTime . '-' . $endTime],
+                'saturday' => [$startTime . '-' . $endTime],
+                'sunday' => [$startTime . '-' . $endTime]
             ]);
         }
 
 
-        $data   = [
-            'monday'     => [],
-            'tuesday'    => [],
-            'wednesday'  => [],
-            'thursday'   => [],
-            'friday'     => [],
-            'saturday'   => [],
-            'sunday'     => [],
+        $data = [
+            'monday' => [],
+            'tuesday' => [],
+            'wednesday' => [],
+            'thursday' => [],
+            'friday' => [],
+            'saturday' => [],
+            'sunday' => [],
             'exceptions' => [
             ]
         ];
         $blocks = explode(';', $osmString);
         foreach ($blocks as $block) {
-            $block        = trim($block);
-            $tokens       = explode(' ', $block);
+            $block = trim($block);
+            $tokens = explode(' ', $block);
             $currentToken = count($tokens) - 1;
 //            $ruleModifier = null;
             $timeSelector = null;
@@ -138,8 +143,8 @@ class OpeningHours {
                 $currentToken--;
             }
 
-            $from  = null;
-            $to    = null;
+            $from = null;
+            $to = null;
             $times = [];
 
             if ($currentToken >= 0 && preg_match(self::RGX_TIME, $tokens[$currentToken])) {
@@ -148,17 +153,17 @@ class OpeningHours {
                 if ($timeSelector === '24/7') {
                     $times[] = [
                         'from' => '00:00',
-                        'to'   => '24:00'
+                        'to' => '24:00'
                     ];
                 } else {
                     $timeSelector = explode(',', $timeSelector);
                     for ($i = 0; $i < count($timeSelector); $i++) {
                         $singleTime = explode('-', $timeSelector[$i]);
-                        $from       = $singleTime[0];
-                        $to         = (count($singleTime) > 1) ? $singleTime[1] : $from;
-                        $times[]    = [
+                        $from = $singleTime[0];
+                        $to = (count($singleTime) > 1) ? $singleTime[1] : $from;
+                        $times[] = [
                             'from' => $from,
-                            'to'   => $to
+                            'to' => $to
                         ];
                     }
                 }
@@ -183,7 +188,7 @@ class OpeningHours {
                         $singleWeekday = explode('-', $singleWeekday);
 
                         $from = array_search($singleWeekday[0], self::OSM_DAYS);
-                        $to   = (count($singleWeekday) > 1) ? array_search($singleWeekday[1], self::OSM_DAYS) : $from;
+                        $to = (count($singleWeekday) > 1) ? array_search($singleWeekday[1], self::OSM_DAYS) : $from;
 
                         $weekdays = array_merge($weekdays, range($from, $to, 1));
                     } else {
@@ -195,7 +200,7 @@ class OpeningHours {
                 $currentToken--;
             }
 
-            $weeks  = [];
+            $weeks = [];
             $months = [];
 
             if ($currentToken >= 0) {
@@ -237,26 +242,28 @@ class OpeningHours {
                                 $months[] = ['holiday' => 'SH'];
                             } elseif (preg_match(self::RGX_MONTH, $singleMonth)) {
                                 $singleMonth = explode('-', $singleMonth);
-                                $from        = array_search($singleMonth[0], self::OSM_MONTHS) + 1;
-                                $to          = (count($singleMonth) > 1)
+                                $from = array_search($singleMonth[0], self::OSM_MONTHS) + 1;
+                                $to = (count($singleMonth) > 1)
                                     ? array_search($singleMonth[1], self::OSM_MONTHS) + 1
                                     : $from;
-                                $months[]    = [
+                                $months[] = [
                                     'from' => $from,
-                                    'to'   => $to
+                                    'to' => $to
                                 ];
                             } elseif (preg_match(self::RGX_MONTHDAY, $singleMonth)) {
                                 $singleMonth = explode('-', str_replace(':', '', $singleMonth));
 
                                 $from = explode(' ', $singleMonth[0]);
-                                $from = sprintf('%02u-%02u', array_search($from[0], self::OSM_MONTHS) + 1, intval($from[1]));
+                                $from = sprintf('%02u-%02u', array_search($from[0], self::OSM_MONTHS) + 1,
+                                    intval($from[1]));
 
                                 if (count($singleMonth) > 1) {
                                     $to = explode(' ', $singleMonth[1]);
                                     if (count($to) === 1) {
                                         $to = substr_replace($from, sprintf('%02u', $to[0]), 3);
                                     } else {
-                                        $to = sprintf('%02u-%02u', array_search($to[0], self::OSM_MONTHS) + 1, intval($to[1]));
+                                        $to = sprintf('%02u-%02u', array_search($to[0], self::OSM_MONTHS) + 1,
+                                            intval($to[1]));
                                     }
                                 } else {
                                     $to = $from;
@@ -265,7 +272,7 @@ class OpeningHours {
 //                                var_dump($singleMonth, $from, $to);
                                 $months[] = [
                                     'from' => $from,
-                                    'to'   => $to
+                                    'to' => $to
                                 ];
                             } else {
                                 throw NotSupportedException::notSupported("month selector '$singleMonth'");
@@ -276,12 +283,12 @@ class OpeningHours {
 
                         for ($i = 0; $i < count($weekSelector); $i++) {
                             $singleWeek = explode('-', $weekSelector[$i]);
-                            $from       = intval($singleWeek[0]);
-                            $to         = (count($singleWeek) > 1) ? intval($singleWeek[1]) : $from;
+                            $from = intval($singleWeek[0]);
+                            $to = (count($singleWeek) > 1) ? intval($singleWeek[1]) : $from;
 
                             $weeks = [
                                 'from' => $from,
-                                'to'   => $to
+                                'to' => $to
                             ];
                         }
                     } else {
@@ -300,7 +307,7 @@ class OpeningHours {
             if (count($times)) {
                 foreach ($times as &$time) {
                     $from = $time['from'];
-                    $to   = $time['to'];
+                    $to = $time['to'];
 
                     $time = ($from === $to) ? $from : $from . '-' . $to;
                 }
@@ -315,27 +322,27 @@ class OpeningHours {
 
                     } else {
                         $from = $month['from'];
-                        $to   = $month['to'];
+                        $to = $month['to'];
 
                         if (false !== (strpos($from, '-'))) {
                             list($fromMonth, $fromDay) = array_map('intval', explode('-', $from));
                             list($toMonth, $toDay) = array_map('intval', explode('-', $to));
                         } else {
                             $fromMonth = intval($from);
-                            $fromDay   = 1;
-                            $toMonth   = intval($to);
-                            $toDay     = intval(date('t', strtotime(date('Y-' . $to . '-d'))));
+                            $fromDay = 1;
+                            $toMonth = intval($to);
+                            $toDay = intval(date('t', strtotime(date('Y-' . $to . '-d'))));
                         }
 
                         for ($m = $fromMonth; $m <= $toMonth; $m++) {
                             $maxDayInMonth = intval(date('t', strtotime(date('Y-' . $m . '-d'))));
-                            $upperLimit    = ($m == $toMonth) ? min($toDay, $maxDayInMonth) : $maxDayInMonth;
-                            $lowerLimit    = ($m == $fromMonth) ? $fromDay : 1;
+                            $upperLimit = ($m == $toMonth) ? min($toDay, $maxDayInMonth) : $maxDayInMonth;
+                            $lowerLimit = ($m == $fromMonth) ? $fromDay : 1;
                             for ($d = $lowerLimit; $d <= $upperLimit; $d++) {
                                 // Check weekday
                                 $weekday = intval(date('w', strtotime(date(sprintf('Y-%02s-%02s', $m, $d)))));
                                 if (false !== array_search($weekday, $weekdays, true)) {
-                                    $key              = sprintf('%02s-%02s', $m, $d);
+                                    $key = sprintf('%02s-%02s', $m, $d);
                                     $exceptions[$key] = $times;
                                 }
                             }
@@ -344,23 +351,23 @@ class OpeningHours {
                 }
                 foreach ($weeks as $week) {
                     $from = $week['from'];
-                    $to   = $week['to'];
-                    $dto  = new DateTime();
+                    $to = $week['to'];
+                    $dto = new DateTime();
                     $dto->setISODate(date('Y'), $from);
                     $fromMonth = intval($dto->format('m'));
-                    $fromDay   = intval($dto->format('d'));
+                    $fromDay = intval($dto->format('d'));
                     $dto->setISODate(date('Y'), $to);
                     $toMonth = intval($dto->format('m'));
-                    $toDay   = intval($dto->format('d'));
+                    $toDay = intval($dto->format('d'));
 
                     for ($m = $fromMonth; $m <= $toMonth; $m++) {
                         $maxDayInMonth = intval(date('t', strtotime(date('Y-' . $m . '-d'))));
-                        $upperLimit    = ($m == $toMonth) ? min($toDay, $maxDayInMonth) : $maxDayInMonth;
-                        $lowerLimit    = ($m == $fromMonth) ? $fromDay : 1;
+                        $upperLimit = ($m == $toMonth) ? min($toDay, $maxDayInMonth) : $maxDayInMonth;
+                        $lowerLimit = ($m == $fromMonth) ? $fromDay : 1;
                         for ($d = $lowerLimit; $d <= $upperLimit; $d++) {
                             $weekday = intval(date('w', strtotime(date(sprintf('Y-%02s-%02s', $m, $d)))));
                             if (false !== array_search($weekday, $weekdays, true)) {
-                                $key              = sprintf('%02s-%02s', $m, $d);
+                                $key = sprintf('%02s-%02s', $m, $d);
                                 $exceptions[$key] = $times;
                             }
                         }
@@ -386,7 +393,8 @@ class OpeningHours {
      * @return static
      * @throws InvalidDayName
      */
-    public function fill(array $data) {
+    public function fill(array $data)
+    {
         list($openingHours, $exceptions) = $this->parseOpeningHoursAndExceptions($data);
 
         foreach ($openingHours as $day => $openingHoursForThisDay) {
@@ -399,19 +407,86 @@ class OpeningHours {
     }
 
     /**
+     * @param array $data
+     * @return array
+     * @throws InvalidDayName
+     */
+    protected function parseOpeningHoursAndExceptions(array $data)
+    {
+        $exceptions = Arr::pull($data, 'exceptions', []);
+        $openingHours = [];
+
+        foreach ($data as $day => $openingHoursData) {
+            $openingHours[$this->normalizeDayName($day)] = $openingHoursData;
+        }
+
+        return [$openingHours, $exceptions];
+    }
+
+    /**
+     * @param string $day
+     * @return string
+     * @throws InvalidDayName
+     */
+    protected function normalizeDayName($day)
+    {
+        $day = strtolower($day);
+
+        if (!Day::isValid($day)) {
+            throw new InvalidDayName();
+        }
+
+        return $day;
+    }
+
+    /**
+     * @param string $day
+     * @param array $openingHours
+     * @throws InvalidDayName
+     */
+    protected function setOpeningHoursFromStrings($day, array $openingHours)
+    {
+        $day = $this->normalizeDayName($day);
+
+        $this->openingHours[$day] = OpeningHoursForDay::fromStrings($openingHours);
+    }
+
+    /**
+     * @param array $exceptions
+     */
+    protected function setExceptionsFromStrings(array $exceptions)
+    {
+        $this->exceptions = Arr::map($exceptions, function (array $openingHours, $date) {
+            $recurring = DateTime::createFromFormat('m-d', $date);
+
+            if ($recurring === false || $recurring->format('m-d') !== $date) {
+                $dateTime = DateTime::createFromFormat('Y-m-d', $date);
+
+                if ($dateTime === false || $dateTime->format('Y-m-d') !== $date) {
+                    throw InvalidDate::invalidDate($date);
+                }
+            }
+
+            return OpeningHoursForDay::fromStrings($openingHours);
+        });
+    }
+
+    /**
      * @return array|Day[]
      */
-    public function forWeek() {
+    public function forWeek()
+    {
         return $this->openingHours;
     }
 
     /**
      * @return array
      */
-    public function forWeekCombined() {
-        $equalDays             = [];
-        $allOpeningHours       = $this->openingHours;
-        $uniqueOpeningHours    = array_unique($allOpeningHours);
+    public function forWeekCombined()
+    {
+        $equalDays = [];
+        $allOpeningHours = $this->openingHours;
+        $uniqueOpeningHours = array_unique($allOpeningHours);
         $nonUniqueOpeningHours = $allOpeningHours;
 
         foreach ($uniqueOpeningHours as $day => $value) {
@@ -431,14 +506,82 @@ class OpeningHours {
     }
 
     /**
+     * @return array
+     */
+    public function exceptions()
+    {
+        return $this->exceptions;
+    }
+
+    /**
+     * @param string $day
+     * @return bool
+     * @throws InvalidDayName
+     */
+    public function isClosedOn($day)
+    {
+        return !$this->isOpenOn($day);
+    }
+
+    /**
+     * @param string $day
+     * @return bool
+     * @throws InvalidDayName
+     */
+    public function isOpenOn($day)
+    {
+        return count($this->forDay($day)) > 0;
+    }
+
+    /**
      * @param string $day
      * @return Day[]
      * @throws InvalidDayName
      */
-    public function forDay($day) {
+    public function forDay($day)
+    {
         $day = $this->normalizeDayName($day);
 
         return $this->openingHours[$day];
+    }
+
+    /**
+     * @return bool
+     * @throws InvalidDayName
+     * @throws Exceptions\InvalidTimeString
+     */
+    public function isOpen()
+    {
+        return $this->isOpenAt(new DateTime());
+    }
+
+    /**
+     * @param DateTimeInterface|Time $dateTime
+     * @return mixed
+     * @throws InvalidDayName
+     * @throws Exceptions\InvalidTimeString
+     */
+    public function isOpenAt(DateTimeInterface $dateTime)
+    {
+        $dateTime = $this->applyTimezone($dateTime);
+
+        $openingHoursForDay = $this->forDate($dateTime);
+
+        return $openingHoursForDay->isOpenAt(Time::fromDateTime($dateTime));
+    }
+
+    /**
+     * @param DateTimeInterface $date
+     * @return DateTimeInterface
+     */
+    protected function applyTimezone(DateTimeInterface $date)
+    {
+        if ($this->timezone) {
+            /* @var $date DateTime */
+            $date = $date->setTimezone($this->timezone);
+        }
+
+        return $date;
     }
 
     /**
@@ -446,7 +589,8 @@ class OpeningHours {
      * @return Day|OpeningHours|Day[]
      * @throws InvalidDayName
      */
-    public function forDate(DateTimeInterface $date) {
+    public function forDate(DateTimeInterface $date)
+    {
         $date = $this->applyTimezone($date);
 
         return isset($this->exceptions[$date->format('Y-m-d')])
@@ -458,42 +602,13 @@ class OpeningHours {
     }
 
     /**
-     * @return array
-     */
-    public function exceptions() {
-        return $this->exceptions;
-    }
-
-    /**
-     * @param string $day
      * @return bool
-     * @throws InvalidDayName
-     */
-    public function isOpenOn($day) {
-        return count($this->forDay($day)) > 0;
-    }
-
-    /**
-     * @param string $day
-     * @return bool
-     * @throws InvalidDayName
-     */
-    public function isClosedOn($day) {
-        return !$this->isOpenOn($day);
-    }
-
-    /**
-     * @param DateTimeInterface|Time $dateTime
-     * @return mixed
      * @throws InvalidDayName
      * @throws Exceptions\InvalidTimeString
      */
-    public function isOpenAt(DateTimeInterface $dateTime) {
-        $dateTime = $this->applyTimezone($dateTime);
-
-        $openingHoursForDay = $this->forDate($dateTime);
-
-        return $openingHoursForDay->isOpenAt(Time::fromDateTime($dateTime));
+    public function isClosed()
+    {
+        return $this->isClosedAt(new DateTime());
     }
 
     /**
@@ -502,26 +617,9 @@ class OpeningHours {
      * @throws InvalidDayName
      * @throws Exceptions\InvalidTimeString
      */
-    public function isClosedAt(DateTimeInterface $dateTime) {
+    public function isClosedAt(DateTimeInterface $dateTime)
+    {
         return !$this->isOpenAt($dateTime);
-    }
-
-    /**
-     * @return bool
-     * @throws InvalidDayName
-     * @throws Exceptions\InvalidTimeString
-     */
-    public function isOpen() {
-        return $this->isOpenAt(new DateTime());
-    }
-
-    /**
-     * @return bool
-     * @throws InvalidDayName
-     * @throws Exceptions\InvalidTimeString
-     */
-    public function isClosed() {
-        return $this->isClosedAt(new DateTime());
     }
 
     /**
@@ -530,9 +628,10 @@ class OpeningHours {
      * @throws InvalidDayName
      * @throws Exceptions\InvalidTimeString
      */
-    public function nextOpen(DateTimeInterface $dateTime) {
+    public function nextOpen(DateTimeInterface $dateTime)
+    {
         $openingHoursForDay = $this->forDate($dateTime);
-        $nextOpen           = $openingHoursForDay->nextOpen(Time::fromDateTime($dateTime));
+        $nextOpen = $openingHoursForDay->nextOpen(Time::fromDateTime($dateTime));
 
         /* @var $dateTime DateTime */
         /* @var $nextOpen Time */
@@ -556,23 +655,35 @@ class OpeningHours {
     /**
      * @return array
      */
-    public function regularClosingDays() {
-        return array_keys($this->filter(function (OpeningHoursForDay $openingHoursForDay) {
-            return $openingHoursForDay->isEmpty();
-        }));
-    }
-
-    /**
-     * @return array
-     */
-    public function regularClosingDaysISO() {
+    public function regularClosingDaysISO()
+    {
         return Arr::map($this->regularClosingDays(), [Day::class, 'toISO']);
     }
 
     /**
      * @return array
      */
-    public function exceptionalClosingDates() {
+    public function regularClosingDays()
+    {
+        return array_keys($this->filter(function (OpeningHoursForDay $openingHoursForDay) {
+            return $openingHoursForDay->isEmpty();
+        }));
+    }
+
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public function filter(callable $callback)
+    {
+        return Arr::filter($this->openingHours, $callback);
+    }
+
+    /**
+     * @return array
+     */
+    public function exceptionalClosingDates()
+    {
         $dates = array_keys($this->filterExceptions(function (OpeningHoursForDay $openingHoursForDay, $date) {
             return $openingHoursForDay->isEmpty();
         }));
@@ -583,99 +694,28 @@ class OpeningHours {
     }
 
     /**
+     * @param callable $callback
+     * @return array
+     */
+    public function filterExceptions(callable $callback)
+    {
+        return Arr::filter($this->exceptions, $callback);
+    }
+
+    /**
      * @param $timezone
      */
-    public function setTimezone($timezone) {
+    public function setTimezone($timezone)
+    {
         $this->timezone = new DateTimeZone($timezone);
     }
 
     /**
-     * @param array $data
-     * @return array
-     * @throws InvalidDayName
-     */
-    protected function parseOpeningHoursAndExceptions(array $data) {
-        $exceptions   = Arr::pull($data, 'exceptions', []);
-        $openingHours = [];
-
-        foreach ($data as $day => $openingHoursData) {
-            $openingHours[$this->normalizeDayName($day)] = $openingHoursData;
-        }
-
-        return [$openingHours, $exceptions];
-    }
-
-    /**
-     * @param string $day
-     * @param array $openingHours
-     * @throws InvalidDayName
-     */
-    protected function setOpeningHoursFromStrings($day, array $openingHours) {
-        $day = $this->normalizeDayName($day);
-
-        $this->openingHours[$day] = OpeningHoursForDay::fromStrings($openingHours);
-    }
-
-    /**
-     * @param array $exceptions
-     */
-    protected function setExceptionsFromStrings(array $exceptions) {
-        $this->exceptions = Arr::map($exceptions, function (array $openingHours, $date) {
-            $recurring = DateTime::createFromFormat('m-d', $date);
-
-            if ($recurring === false || $recurring->format('m-d') !== $date) {
-                $dateTime = DateTime::createFromFormat('Y-m-d', $date);
-
-                if ($dateTime === false || $dateTime->format('Y-m-d') !== $date) {
-                    throw InvalidDate::invalidDate($date);
-                }
-            }
-
-            return OpeningHoursForDay::fromStrings($openingHours);
-        });
-    }
-
-    /**
-     * @param string $day
-     * @return string
-     * @throws InvalidDayName
-     */
-    protected function normalizeDayName($day) {
-        $day = strtolower($day);
-
-        if (!Day::isValid($day)) {
-            throw new InvalidDayName();
-        }
-
-        return $day;
-    }
-
-    /**
-     * @param DateTimeInterface $date
-     * @return DateTimeInterface
-     */
-    protected function applyTimezone(DateTimeInterface $date) {
-        if ($this->timezone) {
-            /* @var $date DateTime */
-            $date = $date->setTimezone($this->timezone);
-        }
-
-        return $date;
-    }
-
-    /**
      * @param callable $callback
      * @return array
      */
-    public function filter(callable $callback) {
-        return Arr::filter($this->openingHours, $callback);
-    }
-
-    /**
-     * @param callable $callback
-     * @return array
-     */
-    public function map(callable $callback) {
+    public function map(callable $callback)
+    {
         return Arr::map($this->openingHours, $callback);
     }
 
@@ -683,45 +723,23 @@ class OpeningHours {
      * @param callable $callback
      * @return array
      */
-    public function flatMap(callable $callback) {
-        return Arr::flatMap($this->openingHours, $callback);
-    }
-
-    /**
-     * @param callable $callback
-     * @return array
-     */
-    public function filterExceptions(callable $callback) {
-        return Arr::filter($this->exceptions, $callback);
-    }
-
-    /**
-     * @param callable $callback
-     * @return array
-     */
-    public function mapExceptions(callable $callback) {
+    public function mapExceptions(callable $callback)
+    {
         return Arr::map($this->exceptions, $callback);
     }
 
     /**
-     * @param callable $callback
      * @return array
      */
-    public function flatMapExceptions(callable $callback) {
-        return Arr::flatMap($this->exceptions, $callback);
-    }
-
-    /**
-     * @return array
-     */
-    public function asStructuredData() {
+    public function asStructuredData()
+    {
         $regularHours = $this->flatMap(function (OpeningHoursForDay $openingHoursForDay, $day) {
             return $openingHoursForDay->map(function (TimeRange $timeRange) use ($day) {
                 return [
-                    '@type'     => 'OpeningHoursSpecification',
+                    '@type' => 'OpeningHoursSpecification',
                     'dayOfWeek' => ucfirst($day),
-                    'opens'     => (string)$timeRange->start(),
-                    'closes'    => (string)$timeRange->end(),
+                    'opens' => (string)$timeRange->start(),
+                    'closes' => (string)$timeRange->end(),
                 ];
             });
         });
@@ -730,10 +748,10 @@ class OpeningHours {
             if ($openingHoursForDay->isEmpty()) {
                 return [
                     [
-                        '@type'        => 'OpeningHoursSpecification',
-                        'opens'        => '00:00',
-                        'closes'       => '00:00',
-                        'validFrom'    => $date,
+                        '@type' => 'OpeningHoursSpecification',
+                        'opens' => '00:00',
+                        'closes' => '00:00',
+                        'validFrom' => $date,
                         'validThrough' => $date,
                     ]
                 ];
@@ -741,15 +759,33 @@ class OpeningHours {
 
             return $openingHoursForDay->map(function (TimeRange $timeRange) use ($date) {
                 return [
-                    '@type'        => 'OpeningHoursSpecification',
-                    'opens'        => $timeRange->start(),
-                    'closes'       => $timeRange->end(),
-                    'validFrom'    => $date,
+                    '@type' => 'OpeningHoursSpecification',
+                    'opens' => $timeRange->start(),
+                    'closes' => $timeRange->end(),
+                    'validFrom' => $date,
                     'validThrough' => $date,
                 ];
             });
         });
 
         return array_merge($regularHours, $exceptions);
+    }
+
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public function flatMap(callable $callback)
+    {
+        return Arr::flatMap($this->openingHours, $callback);
+    }
+
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public function flatMapExceptions(callable $callback)
+    {
+        return Arr::flatMap($this->exceptions, $callback);
     }
 }

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -3,26 +3,49 @@
 namespace Spatie\OpeningHours;
 
 use DateTime;
-use DateTimeZone;
 use DateTimeInterface;
-use Spatie\OpeningHours\Helpers\Arr;
+use DateTimeZone;
 use Spatie\OpeningHours\Exceptions\Exception;
 use Spatie\OpeningHours\Exceptions\InvalidDate;
 use Spatie\OpeningHours\Exceptions\InvalidDayName;
+use Spatie\OpeningHours\Exceptions\NotSupportedException;
+use Spatie\OpeningHours\Helpers\Arr;
 
-class OpeningHours
-{
+class OpeningHours {
     /** @var \Spatie\OpeningHours\Day[] */
     protected $openingHours = [];
-
     /** @var array */
     protected $exceptions = [];
-
     /** @var DateTimeZone|null */
     protected $timezone = null;
+    const RGX_RULE_MODIFIER = '/^(open|closed|off)$/i';
+    const RGX_WEEK_KEY = '/^week$/';
+    const RGX_WEEK_VAL = '/^([01234]?[0-9]|5[0123])(-([01234]?[0-9]|5[0123]))?(,([01234]?[0-9]|5[0123])(-([01234]?[0-9]|5[0123]))?)*:?$/';
+    const RGX_MONTH = '/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)(-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec))?:?$/';
+    const RGX_MONTHDAY = '/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([012]?[0-9]|3[01])(-((Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) )?([012]?[0-9]|3[01]))?:?$/';
+    const RGX_TIME = '/^((([01]?[0-9]|2[01234]):[012345][0-9](-([01]?[0-9]|2[01234]):[012345][0-9])?(,([01]?[0-9]|2[01234]):[012345][0-9](-([01]?[0-9]|2[01234]):[012345][0-9])?)*)|(24\/7))$/';
+    const RGX_WEEKDAY = '/^(((Mo|Tu|We|Th|Fr|Sa|Su)(-(Mo|Tu|We|Th|Fr|Sa|Su))?)|(PH|SH|easter))(,(((Mo|Tu|We|Th|Fr|Sa|Su)(-(Mo|Tu|We|Th|Fr|Sa|Su))?)|(PH|SH|easter)))*$/';
+    const RGX_HOLIDAY = '/^(PH|SH|easter)$/';
+    const RGX_WD = '/^(Mo|Tu|We|Th|Fr|Sa|Su)(-(Mo|Tu|We|Th|Fr|Sa|Su))?$/';
+    const OSM_DAYS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+    const IRL_DAYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+    const OSM_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const IRL_MONTHS = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December'
+    ];
 
-    public function __construct($timezone = null)
-    {
+    public function __construct($timezone = null) {
         $this->timezone = $timezone ? new DateTimeZone($timezone) : null;
 
         $this->openingHours = Day::mapDays(function () {
@@ -31,12 +54,15 @@ class OpeningHours
     }
 
     /**
-     * @param array $data
+     * @param array|string $data
      *
      * @return static
      */
-    public static function create(array $data)
-    {
+    public static function create($data) {
+        if (is_string($data)) {
+            return (new static())->fromOsmString($data);
+        }
+
         return (new static())->fill($data);
     }
 
@@ -45,8 +71,7 @@ class OpeningHours
      *
      * @return bool
      */
-    public static function isValid(array $data): bool
-    {
+    public static function isValid(array $data) {
         try {
             static::create($data);
 
@@ -56,8 +81,312 @@ class OpeningHours
         }
     }
 
-    public function fill(array $data)
-    {
+    /**
+     * @param string $osmString
+     * @return static
+     * @throws NotSupportedException
+     * @throws InvalidDate
+     */
+    public static function fromOsmString($osmString) {
+        if ($osmString === '24/7') {
+            return (new static())->fill([
+                'monday'    => ['00:00-24:00'],
+                'tuesday'   => ['00:00-24:00'],
+                'wednesday' => ['00:00-24:00'],
+                'thursday'  => ['00:00-24:00'],
+                'friday'    => ['00:00-24:00'],
+                'saturday'  => ['00:00-24:00'],
+                'sunday'    => ['00:00-24:00']
+            ]);
+        } elseif (preg_match('#([^\(]?sunrise.*[^\)-]+).*-.*([^\(]?sunset.*[^\)])#u', $osmString)) {
+            $startTime = date_sunrise(time(), SUNFUNCS_RET_STRING);
+            $endTime   = date_sunrise(time(), SUNFUNCS_RET_STRING);
+
+            return (new static())->fill([
+                'monday'    => [$startTime . '-' . $endTime],
+                'tuesday'   => [$startTime . '-' . $endTime],
+                'wednesday' => [$startTime . '-' . $endTime],
+                'thursday'  => [$startTime . '-' . $endTime],
+                'friday'    => [$startTime . '-' . $endTime],
+                'saturday'  => [$startTime . '-' . $endTime],
+                'sunday'    => [$startTime . '-' . $endTime]
+            ]);
+        }
+
+
+        $data   = [
+            'monday'     => [],
+            'tuesday'    => [],
+            'wednesday'  => [],
+            'thursday'   => [],
+            'friday'     => [],
+            'saturday'   => [],
+            'sunday'     => [],
+            'exceptions' => [
+            ]
+        ];
+        $blocks = explode(';', $osmString);
+        foreach ($blocks as $block) {
+            $block        = trim($block);
+            $tokens       = explode(' ', $block);
+            $currentToken = count($tokens) - 1;
+//            $ruleModifier = null;
+            $timeSelector = null;
+
+            if ($currentToken >= 0 && preg_match(self::RGX_RULE_MODIFIER, $tokens[$currentToken])) {
+//                $ruleModifier = strtolower($tokens[$currentToken]);
+                $currentToken--;
+            }
+
+            $from  = null;
+            $to    = null;
+            $times = [];
+
+            if ($currentToken >= 0 && preg_match(self::RGX_TIME, $tokens[$currentToken])) {
+                $timeSelector = $tokens[$currentToken];
+
+                if ($timeSelector === '24/7') {
+                    $times[] = [
+                        'from' => '00:00',
+                        'to'   => '24:00'
+                    ];
+                } else {
+                    $timeSelector = explode(',', $timeSelector);
+                    for ($i = 0; $i < count($timeSelector); $i++) {
+                        $singleTime = explode('-', $timeSelector[$i]);
+                        $from       = $singleTime[0];
+                        $to         = (count($singleTime) > 1) ? $singleTime[1] : $from;
+                        $times[]    = [
+                            'from' => $from,
+                            'to'   => $to
+                        ];
+                    }
+                }
+
+                $currentToken--;
+            }
+
+            $holidays = [];
+            $weekdays = [];
+
+            if ($timeSelector === '24/7') {
+                $weekdays = range(0, 6, 1);
+            } elseif ($currentToken >= 0 && preg_match(self::RGX_WEEKDAY, $tokens[$currentToken])) {
+                $weekdaySelector = explode(',', $tokens[$currentToken]);
+
+                for ($i = 0; $i < count($weekdaySelector); $i++) {
+                    $singleWeekday = $weekdaySelector[$i];
+
+                    if (preg_match(self::RGX_HOLIDAY, $singleWeekday)) { // Holiday
+                        $holidays[] = $singleWeekday;
+                    } elseif (preg_match(self::RGX_WD, $singleWeekday)) { // Weekday interval
+                        $singleWeekday = explode('-', $singleWeekday);
+
+                        $from = array_search($singleWeekday[0], self::OSM_DAYS);
+                        $to   = (count($singleWeekday) > 1) ? array_search($singleWeekday[1], self::OSM_DAYS) : $from;
+
+                        $weekdays = array_merge($weekdays, range($from, $to, 1));
+                    } else {
+                        // throw exception ?
+                        continue;
+                    }
+                }
+
+                $currentToken--;
+            }
+
+            $weeks  = [];
+            $months = [];
+
+            if ($currentToken >= 0) {
+                $wideRangeSelector = $tokens[0];
+
+                for ($ct = 1; $ct <= $currentToken; $ct++) {
+                    $wideRangeSelector .= ' ' . $tokens[$ct];
+                }
+
+                if (!empty($wideRangeSelector)) {
+                    $wideRangeSelector = explode('week', preg_replace('#:$#', '', $wideRangeSelector));
+
+                    // Month or SH
+                    $monthSelector = trim($wideRangeSelector[0]);
+                    if (empty($monthSelector)) {
+                        $monthSelector = null;
+                    }
+
+                    // Weeks
+                    if (count($wideRangeSelector) > 1) {
+                        $weekSelector = trim($wideRangeSelector[1]);
+                        if (empty($weekSelector)) {
+                            $weekSelector = null;
+                        }
+                    } else {
+                        $weekSelector = null;
+                    }
+
+                    if ($monthSelector && $weekSelector) {
+                        throw NotSupportedException::notSupported('simultaneous month and week selector');
+                    } elseif ($monthSelector) {
+                        $monthSelector = explode(',', $monthSelector);
+
+                        for ($i = 0; $i < count($monthSelector); $i++) {
+                            $singleMonth = $monthSelector[$i];
+
+                            // School holidays
+                            if ($singleMonth === 'SH') {
+                                $months[] = ['holiday' => 'SH'];
+                            } elseif (preg_match(self::RGX_MONTH, $singleMonth)) {
+                                $singleMonth = explode('-', $singleMonth);
+                                $from        = array_search($singleMonth[0], self::OSM_MONTHS) + 1;
+                                $to          = (count($singleMonth) > 1)
+                                    ? array_search($singleMonth[1], self::OSM_MONTHS) + 1
+                                    : $from;
+                                $months[]    = [
+                                    'from' => $from,
+                                    'to'   => $to
+                                ];
+                            } elseif (preg_match(self::RGX_MONTHDAY, $singleMonth)) {
+                                $singleMonth = explode('-', str_replace(':', '', $singleMonth));
+
+                                $from = explode(' ', $singleMonth[0]);
+                                $from = sprintf('%02u-%02u', array_search($from[0], self::OSM_MONTHS) + 1, intval($from[1]));
+
+                                if (count($singleMonth) > 1) {
+                                    $to = explode(' ', $singleMonth[1]);
+                                    if (count($to) === 1) {
+                                        $to = substr_replace($from, sprintf('%02u', $to[0]), 3);
+                                    } else {
+                                        $to = sprintf('%02u-%02u', array_search($to[0], self::OSM_MONTHS) + 1, intval($to[1]));
+                                    }
+                                } else {
+                                    $to = $from;
+                                }
+
+//                                var_dump($singleMonth, $from, $to);
+                                $months[] = [
+                                    'from' => $from,
+                                    'to'   => $to
+                                ];
+                            } else {
+                                throw NotSupportedException::notSupported("month selector '$singleMonth'");
+                            }
+                        }
+                    } elseif ($weekSelector) {
+                        $weekSelector = explode(',', $weekSelector);
+
+                        for ($i = 0; $i < count($weekSelector); $i++) {
+                            $singleWeek = explode('-', $weekSelector[$i]);
+                            $from       = intval($singleWeek[0]);
+                            $to         = (count($singleWeek) > 1) ? intval($singleWeek[1]) : $from;
+
+                            $weeks = [
+                                'from' => $from,
+                                'to'   => $to
+                            ];
+                        }
+                    } else {
+                        throw InvalidDate::invalidDate($block);
+                    }
+                }
+            }
+
+            if ($currentToken === count($tokens) - 1) {
+                continue;
+            }
+
+            if (empty($weekdays)) {
+                $weekdays = range(0, 6, 1);
+            }
+            if (count($times)) {
+                foreach ($times as &$time) {
+                    $from = $time['from'];
+                    $to   = $time['to'];
+
+                    $time = ($from === $to) ? $from : $from . '-' . $to;
+                }
+            } else {
+                $times = [];
+            }
+            // Exceptions
+            if (count($months) || count($weeks)) {
+                $exceptions = [];
+                foreach ($months as $month) {
+                    if (isset($month['holiday'])) {
+
+                    } else {
+                        $from = $month['from'];
+                        $to   = $month['to'];
+
+                        if (false !== (strpos($from, '-'))) {
+                            list($fromMonth, $fromDay) = array_map('intval', explode('-', $from));
+                            list($toMonth, $toDay) = array_map('intval', explode('-', $to));
+                        } else {
+                            $fromMonth = intval($from);
+                            $fromDay   = 1;
+                            $toMonth   = intval($to);
+                            $toDay     = intval(date('t', strtotime(date('Y-' . $to . '-d'))));
+                        }
+
+                        for ($m = $fromMonth; $m <= $toMonth; $m++) {
+                            $maxDayInMonth = intval(date('t', strtotime(date('Y-' . $m . '-d'))));
+                            $upperLimit    = ($m == $toMonth) ? min($toDay, $maxDayInMonth) : $maxDayInMonth;
+                            $lowerLimit    = ($m == $fromMonth) ? $fromDay : 1;
+                            for ($d = $lowerLimit; $d <= $upperLimit; $d++) {
+                                // Check weekday
+                                $weekday = intval(date('w', strtotime(date(sprintf('Y-%02s-%02s', $m, $d)))));
+                                if (false !== array_search($weekday, $weekdays, true)) {
+                                    $key              = sprintf('%02s-%02s', $m, $d);
+                                    $exceptions[$key] = $times;
+                                }
+                            }
+                        }
+                    }
+                }
+                foreach ($weeks as $week) {
+                    $from = $week['from'];
+                    $to   = $week['to'];
+                    $dto  = new DateTime();
+                    $dto->setISODate(date('Y'), $from);
+                    $fromMonth = intval($dto->format('m'));
+                    $fromDay   = intval($dto->format('d'));
+                    $dto->setISODate(date('Y'), $to);
+                    $toMonth = intval($dto->format('m'));
+                    $toDay   = intval($dto->format('d'));
+
+                    for ($m = $fromMonth; $m <= $toMonth; $m++) {
+                        $maxDayInMonth = intval(date('t', strtotime(date('Y-' . $m . '-d'))));
+                        $upperLimit    = ($m == $toMonth) ? min($toDay, $maxDayInMonth) : $maxDayInMonth;
+                        $lowerLimit    = ($m == $fromMonth) ? $fromDay : 1;
+                        for ($d = $lowerLimit; $d <= $upperLimit; $d++) {
+                            $weekday = intval(date('w', strtotime(date(sprintf('Y-%02s-%02s', $m, $d)))));
+                            if (false !== array_search($weekday, $weekdays, true)) {
+                                $key              = sprintf('%02s-%02s', $m, $d);
+                                $exceptions[$key] = $times;
+                            }
+                        }
+                    }
+                }
+
+                $data['exceptions'] = array_merge($data['exceptions'], $exceptions);
+            } elseif (count($holidays)) {
+                // Not supported yet
+                continue;
+            } else {
+                foreach ($weekdays as $weekday) {
+                    $data[self::IRL_DAYS[$weekday]] = $times;
+                }
+            }
+        }
+
+        return (new static())->fill($data);
+    }
+
+    /**
+     * @param array $data
+     * @return static
+     * @throws InvalidDayName
+     */
+    public function fill(array $data) {
         list($openingHours, $exceptions) = $this->parseOpeningHoursAndExceptions($data);
 
         foreach ($openingHours as $day => $openingHoursForThisDay) {
@@ -69,16 +398,20 @@ class OpeningHours
         return $this;
     }
 
-    public function forWeek(): array
-    {
+    /**
+     * @return array|Day[]
+     */
+    public function forWeek() {
         return $this->openingHours;
     }
 
-    public function forWeekCombined(): array
-    {
-        $equalDays = [];
-        $allOpeningHours = $this->openingHours;
-        $uniqueOpeningHours = array_unique($allOpeningHours);
+    /**
+     * @return array
+     */
+    public function forWeekCombined() {
+        $equalDays             = [];
+        $allOpeningHours       = $this->openingHours;
+        $uniqueOpeningHours    = array_unique($allOpeningHours);
         $nonUniqueOpeningHours = $allOpeningHours;
 
         foreach ($uniqueOpeningHours as $day => $value) {
@@ -88,7 +421,7 @@ class OpeningHours
 
         foreach ($uniqueOpeningHours as $uniqueDay => $uniqueValue) {
             foreach ($nonUniqueOpeningHours as $nonUniqueDay => $nonUniqueValue) {
-                if ((string) $uniqueValue === (string) $nonUniqueValue) {
+                if ((string)$uniqueValue === (string)$nonUniqueValue) {
                     $equalDays[$uniqueDay]['days'][] = $nonUniqueDay;
                 }
             }
@@ -97,37 +430,65 @@ class OpeningHours
         return $equalDays;
     }
 
-    public function forDay(string $day): OpeningHoursForDay
-    {
+    /**
+     * @param string $day
+     * @return Day[]
+     * @throws InvalidDayName
+     */
+    public function forDay($day) {
         $day = $this->normalizeDayName($day);
 
         return $this->openingHours[$day];
     }
 
-    public function forDate(DateTimeInterface $date): OpeningHoursForDay
-    {
+    /**
+     * @param DateTimeInterface $date
+     * @return Day|OpeningHours|Day[]
+     * @throws InvalidDayName
+     */
+    public function forDate(DateTimeInterface $date) {
         $date = $this->applyTimezone($date);
 
-        return $this->exceptions[$date->format('Y-m-d')] ?? ($this->exceptions[$date->format('m-d')] ?? $this->forDay(Day::onDateTime($date)));
+        return isset($this->exceptions[$date->format('Y-m-d')])
+            ? $this->exceptions[$date->format('Y-m-d')]
+            : (isset($this->exceptions[$date->format('m-d')])
+                ? $this->exceptions[$date->format('m-d')]
+                : $this->forDay(Day::onDateTime($date))
+            );
     }
 
-    public function exceptions(): array
-    {
+    /**
+     * @return array
+     */
+    public function exceptions() {
         return $this->exceptions;
     }
 
-    public function isOpenOn(string $day): bool
-    {
+    /**
+     * @param string $day
+     * @return bool
+     * @throws InvalidDayName
+     */
+    public function isOpenOn($day) {
         return count($this->forDay($day)) > 0;
     }
 
-    public function isClosedOn(string $day): bool
-    {
-        return ! $this->isOpenOn($day);
+    /**
+     * @param string $day
+     * @return bool
+     * @throws InvalidDayName
+     */
+    public function isClosedOn($day) {
+        return !$this->isOpenOn($day);
     }
 
-    public function isOpenAt(DateTimeInterface $dateTime): bool
-    {
+    /**
+     * @param DateTimeInterface|Time $dateTime
+     * @return mixed
+     * @throws InvalidDayName
+     * @throws Exceptions\InvalidTimeString
+     */
+    public function isOpenAt(DateTimeInterface $dateTime) {
         $dateTime = $this->applyTimezone($dateTime);
 
         $openingHoursForDay = $this->forDate($dateTime);
@@ -135,25 +496,46 @@ class OpeningHours
         return $openingHoursForDay->isOpenAt(Time::fromDateTime($dateTime));
     }
 
-    public function isClosedAt(DateTimeInterface $dateTime): bool
-    {
-        return ! $this->isOpenAt($dateTime);
+    /**
+     * @param DateTimeInterface $dateTime
+     * @return bool
+     * @throws InvalidDayName
+     * @throws Exceptions\InvalidTimeString
+     */
+    public function isClosedAt(DateTimeInterface $dateTime) {
+        return !$this->isOpenAt($dateTime);
     }
 
-    public function isOpen(): bool
-    {
+    /**
+     * @return bool
+     * @throws InvalidDayName
+     * @throws Exceptions\InvalidTimeString
+     */
+    public function isOpen() {
         return $this->isOpenAt(new DateTime());
     }
 
-    public function isClosed(): bool
-    {
+    /**
+     * @return bool
+     * @throws InvalidDayName
+     * @throws Exceptions\InvalidTimeString
+     */
+    public function isClosed() {
         return $this->isClosedAt(new DateTime());
     }
 
-    public function nextOpen(DateTimeInterface $dateTime): DateTime
-    {
+    /**
+     * @param DateTimeInterface|Time $dateTime
+     * @return DateTimeInterface
+     * @throws InvalidDayName
+     * @throws Exceptions\InvalidTimeString
+     */
+    public function nextOpen(DateTimeInterface $dateTime) {
         $openingHoursForDay = $this->forDate($dateTime);
-        $nextOpen = $openingHoursForDay->nextOpen(Time::fromDateTime($dateTime));
+        $nextOpen           = $openingHoursForDay->nextOpen(Time::fromDateTime($dateTime));
+
+        /* @var $dateTime DateTime */
+        /* @var $nextOpen Time */
 
         while ($nextOpen == false) {
             $dateTime
@@ -171,20 +553,26 @@ class OpeningHours
         return $dateTime;
     }
 
-    public function regularClosingDays(): array
-    {
+    /**
+     * @return array
+     */
+    public function regularClosingDays() {
         return array_keys($this->filter(function (OpeningHoursForDay $openingHoursForDay) {
             return $openingHoursForDay->isEmpty();
         }));
     }
 
-    public function regularClosingDaysISO(): array
-    {
+    /**
+     * @return array
+     */
+    public function regularClosingDaysISO() {
         return Arr::map($this->regularClosingDays(), [Day::class, 'toISO']);
     }
 
-    public function exceptionalClosingDates(): array
-    {
+    /**
+     * @return array
+     */
+    public function exceptionalClosingDates() {
         $dates = array_keys($this->filterExceptions(function (OpeningHoursForDay $openingHoursForDay, $date) {
             return $openingHoursForDay->isEmpty();
         }));
@@ -194,14 +582,20 @@ class OpeningHours
         });
     }
 
-    public function setTimezone($timezone)
-    {
+    /**
+     * @param $timezone
+     */
+    public function setTimezone($timezone) {
         $this->timezone = new DateTimeZone($timezone);
     }
 
-    protected function parseOpeningHoursAndExceptions(array $data): array
-    {
-        $exceptions = Arr::pull($data, 'exceptions', []);
+    /**
+     * @param array $data
+     * @return array
+     * @throws InvalidDayName
+     */
+    protected function parseOpeningHoursAndExceptions(array $data) {
+        $exceptions   = Arr::pull($data, 'exceptions', []);
         $openingHours = [];
 
         foreach ($data as $day => $openingHoursData) {
@@ -211,16 +605,22 @@ class OpeningHours
         return [$openingHours, $exceptions];
     }
 
-    protected function setOpeningHoursFromStrings(string $day, array $openingHours)
-    {
+    /**
+     * @param string $day
+     * @param array $openingHours
+     * @throws InvalidDayName
+     */
+    protected function setOpeningHoursFromStrings($day, array $openingHours) {
         $day = $this->normalizeDayName($day);
 
         $this->openingHours[$day] = OpeningHoursForDay::fromStrings($openingHours);
     }
 
-    protected function setExceptionsFromStrings(array $exceptions)
-    {
-        $this->exceptions = Arr::map($exceptions, function (array $openingHours, string $date) {
+    /**
+     * @param array $exceptions
+     */
+    protected function setExceptionsFromStrings(array $exceptions) {
+        $this->exceptions = Arr::map($exceptions, function (array $openingHours, $date) {
             $recurring = DateTime::createFromFormat('m-d', $date);
 
             if ($recurring === false || $recurring->format('m-d') !== $date) {
@@ -235,86 +635,116 @@ class OpeningHours
         });
     }
 
-    protected function normalizeDayName(string $day)
-    {
+    /**
+     * @param string $day
+     * @return string
+     * @throws InvalidDayName
+     */
+    protected function normalizeDayName($day) {
         $day = strtolower($day);
 
-        if (! Day::isValid($day)) {
+        if (!Day::isValid($day)) {
             throw new InvalidDayName();
         }
 
         return $day;
     }
 
-    protected function applyTimezone(DateTimeInterface $date)
-    {
+    /**
+     * @param DateTimeInterface $date
+     * @return DateTimeInterface
+     */
+    protected function applyTimezone(DateTimeInterface $date) {
         if ($this->timezone) {
+            /* @var $date DateTime */
             $date = $date->setTimezone($this->timezone);
         }
 
         return $date;
     }
 
-    public function filter(callable $callback): array
-    {
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public function filter(callable $callback) {
         return Arr::filter($this->openingHours, $callback);
     }
 
-    public function map(callable $callback): array
-    {
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public function map(callable $callback) {
         return Arr::map($this->openingHours, $callback);
     }
 
-    public function flatMap(callable $callback): array
-    {
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public function flatMap(callable $callback) {
         return Arr::flatMap($this->openingHours, $callback);
     }
 
-    public function filterExceptions(callable $callback): array
-    {
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public function filterExceptions(callable $callback) {
         return Arr::filter($this->exceptions, $callback);
     }
 
-    public function mapExceptions(callable $callback): array
-    {
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public function mapExceptions(callable $callback) {
         return Arr::map($this->exceptions, $callback);
     }
 
-    public function flatMapExceptions(callable $callback): array
-    {
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public function flatMapExceptions(callable $callback) {
         return Arr::flatMap($this->exceptions, $callback);
     }
 
-    public function asStructuredData(): array
-    {
-        $regularHours = $this->flatMap(function (OpeningHoursForDay $openingHoursForDay, string $day) {
+    /**
+     * @return array
+     */
+    public function asStructuredData() {
+        $regularHours = $this->flatMap(function (OpeningHoursForDay $openingHoursForDay, $day) {
             return $openingHoursForDay->map(function (TimeRange $timeRange) use ($day) {
                 return [
-                    '@type' => 'OpeningHoursSpecification',
+                    '@type'     => 'OpeningHoursSpecification',
                     'dayOfWeek' => ucfirst($day),
-                    'opens' => (string) $timeRange->start(),
-                    'closes' => (string) $timeRange->end(),
+                    'opens'     => (string)$timeRange->start(),
+                    'closes'    => (string)$timeRange->end(),
                 ];
             });
         });
 
-        $exceptions = $this->flatMapExceptions(function (OpeningHoursForDay $openingHoursForDay, string $date) {
+        $exceptions = $this->flatMapExceptions(function (OpeningHoursForDay $openingHoursForDay, $date) {
             if ($openingHoursForDay->isEmpty()) {
-                return [[
-                    '@type' => 'OpeningHoursSpecification',
-                    'opens' => '00:00',
-                    'closes' => '00:00',
-                    'validFrom' => $date,
-                    'validThrough' => $date,
-                ]];
+                return [
+                    [
+                        '@type'        => 'OpeningHoursSpecification',
+                        'opens'        => '00:00',
+                        'closes'       => '00:00',
+                        'validFrom'    => $date,
+                        'validThrough' => $date,
+                    ]
+                ];
             }
 
             return $openingHoursForDay->map(function (TimeRange $timeRange) use ($date) {
                 return [
-                    '@type' => 'OpeningHoursSpecification',
-                    'opens' => $timeRange->start(),
-                    'closes' => $timeRange->end(),
-                    'validFrom' => $date,
+                    '@type'        => 'OpeningHoursSpecification',
+                    'opens'        => $timeRange->start(),
+                    'closes'       => $timeRange->end(),
+                    'validFrom'    => $date,
                     'validThrough' => $date,
                 ];
             });

--- a/src/OpeningHoursForDay.php
+++ b/src/OpeningHoursForDay.php
@@ -9,7 +9,8 @@ use IteratorAggregate;
 use Spatie\OpeningHours\Exceptions\OverlappingTimeRanges;
 use Spatie\OpeningHours\Helpers\Arr;
 
-class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
+class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
+{
     /** @var \Spatie\OpeningHours\TimeRange[] */
     protected $openingHours = [];
 
@@ -17,7 +18,8 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
      * @param array $strings
      * @return OpeningHoursForDay
      */
-    public static function fromStrings(array $strings) {
+    public static function fromStrings(array $strings)
+    {
         $openingHoursForDay = new static();
 
         $timeRanges = Arr::map($strings, function ($string) {
@@ -32,10 +34,25 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
     }
 
     /**
+     * @param array $openingHours
+     * @throws OverlappingTimeRanges
+     */
+    protected function guardAgainstTimeRangeOverlaps(array $openingHours)
+    {
+        foreach (Arr::createUniquePairs($openingHours) as $timeRanges) {
+            /* @var $timeRanges TimeRange[] */
+            if ($timeRanges[0]->overlaps($timeRanges[1])) {
+                throw OverlappingTimeRanges::forRanges($timeRanges[0], $timeRanges[1]);
+            }
+        }
+    }
+
+    /**
      * @param Time $time
      * @return bool
      */
-    public function isOpenAt(Time $time) {
+    public function isOpenAt(Time $time)
+    {
         foreach ($this->openingHours as $timeRange) {
             if ($timeRange->containsTime($time)) {
                 return true;
@@ -51,7 +68,8 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
      * @throws Exceptions\InvalidTimeRangeString
      * @throws Exceptions\InvalidTimeString
      */
-    public function nextOpen(Time $time) {
+    public function nextOpen(Time $time)
+    {
         foreach ($this->openingHours as $timeRange) {
             if ($nextOpen = $this->findNextOpenInWorkingHours($time, $timeRange)) {
                 return $nextOpen;
@@ -70,7 +88,8 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
      * @param TimeRange $timeRange
      * @return TimeRange|null
      */
-    protected function findNextOpenInWorkingHours(Time $time, TimeRange $timeRange) {
+    protected function findNextOpenInWorkingHours(Time $time, TimeRange $timeRange)
+    {
         if ($timeRange->containsTime($time) && next($timeRange) !== $timeRange) {
             return next($timeRange);
         }
@@ -86,7 +105,8 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
      * @throws Exceptions\InvalidTimeRangeString
      * @throws Exceptions\InvalidTimeString
      */
-    protected function findNextOpenInFreeTime(Time $time, TimeRange $timeRange, TimeRange &$prevTimeRange = null) {
+    protected function findNextOpenInFreeTime(Time $time, TimeRange $timeRange, TimeRange &$prevTimeRange = null)
+    {
         $timeOffRange = $prevTimeRange
             ?
             TimeRange::fromString($prevTimeRange->end() . '-' . $timeRange->start())
@@ -106,7 +126,8 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
      * @param mixed $offset
      * @return bool
      */
-    public function offsetExists($offset) {
+    public function offsetExists($offset)
+    {
         return isset($this->openingHours[$offset]);
     }
 
@@ -114,7 +135,8 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
      * @param mixed $offset
      * @return mixed|TimeRange
      */
-    public function offsetGet($offset) {
+    public function offsetGet($offset)
+    {
         return $this->openingHours[$offset];
     }
 
@@ -123,35 +145,40 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
      * @param mixed $value
      * @throws \Exception
      */
-    public function offsetSet($offset, $value) {
+    public function offsetSet($offset, $value)
+    {
         throw new \Exception();
     }
 
     /**
      * @param mixed $offset
      */
-    public function offsetUnset($offset) {
+    public function offsetUnset($offset)
+    {
         unset($this->openingHours[$offset]);
     }
 
     /**
      * @return int
      */
-    public function count() {
+    public function count()
+    {
         return count($this->openingHours);
     }
 
     /**
      * @return ArrayIterator|\Traversable
      */
-    public function getIterator() {
+    public function getIterator()
+    {
         return new ArrayIterator($this->openingHours);
     }
 
     /**
      * @return bool
      */
-    public function isEmpty() {
+    public function isEmpty()
+    {
         return empty($this->openingHours);
     }
 
@@ -159,27 +186,16 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
      * @param callable $callback
      * @return array
      */
-    public function map(callable $callback) {
+    public function map(callable $callback)
+    {
         return Arr::map($this->openingHours, $callback);
-    }
-
-    /**
-     * @param array $openingHours
-     * @throws OverlappingTimeRanges
-     */
-    protected function guardAgainstTimeRangeOverlaps(array $openingHours) {
-        foreach (Arr::createUniquePairs($openingHours) as $timeRanges) {
-            /* @var $timeRanges TimeRange[] */
-            if ($timeRanges[0]->overlaps($timeRanges[1])) {
-                throw OverlappingTimeRanges::forRanges($timeRanges[0], $timeRanges[1]);
-            }
-        }
     }
 
     /**
      * @return string
      */
-    public function __toString() {
+    public function __toString()
+    {
         $values = [];
         foreach ($this->openingHours as $openingHour) {
             $values[] = (string)$openingHour;

--- a/src/OpeningHoursForDay.php
+++ b/src/OpeningHoursForDay.php
@@ -2,20 +2,22 @@
 
 namespace Spatie\OpeningHours;
 
-use Countable;
 use ArrayAccess;
 use ArrayIterator;
+use Countable;
 use IteratorAggregate;
-use Spatie\OpeningHours\Helpers\Arr;
 use Spatie\OpeningHours\Exceptions\OverlappingTimeRanges;
+use Spatie\OpeningHours\Helpers\Arr;
 
-class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
-{
+class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate {
     /** @var \Spatie\OpeningHours\TimeRange[] */
     protected $openingHours = [];
 
-    public static function fromStrings(array $strings)
-    {
+    /**
+     * @param array $strings
+     * @return OpeningHoursForDay
+     */
+    public static function fromStrings(array $strings) {
         $openingHoursForDay = new static();
 
         $timeRanges = Arr::map($strings, function ($string) {
@@ -29,8 +31,11 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
         return $openingHoursForDay;
     }
 
-    public function isOpenAt(Time $time)
-    {
+    /**
+     * @param Time $time
+     * @return bool
+     */
+    public function isOpenAt(Time $time) {
         foreach ($this->openingHours as $timeRange) {
             if ($timeRange->containsTime($time)) {
                 return true;
@@ -40,8 +45,13 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
         return false;
     }
 
-    public function nextOpen(Time $time)
-    {
+    /**
+     * @param Time $time
+     * @return bool|mixed|Time
+     * @throws Exceptions\InvalidTimeRangeString
+     * @throws Exceptions\InvalidTimeString
+     */
+    public function nextOpen(Time $time) {
         foreach ($this->openingHours as $timeRange) {
             if ($nextOpen = $this->findNextOpenInWorkingHours($time, $timeRange)) {
                 return $nextOpen;
@@ -55,80 +65,124 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
         return false;
     }
 
-    protected function findNextOpenInWorkingHours(Time $time, TimeRange $timeRange)
-    {
+    /**
+     * @param Time $time
+     * @param TimeRange $timeRange
+     * @return TimeRange|null
+     */
+    protected function findNextOpenInWorkingHours(Time $time, TimeRange $timeRange) {
         if ($timeRange->containsTime($time) && next($timeRange) !== $timeRange) {
             return next($timeRange);
         }
+
+        return null;
     }
 
-    protected function findNextOpenInFreeTime(Time $time, TimeRange $timeRange, TimeRange &$prevTimeRange = null)
-    {
-        $timeOffRange = $prevTimeRange ?
-            TimeRange::fromString($prevTimeRange->end().'-'.$timeRange->start()) :
-            TimeRange::fromString('00:00-'.$timeRange->start());
+    /**
+     * @param Time $time
+     * @param TimeRange $timeRange
+     * @param TimeRange|null $prevTimeRange
+     * @return Time|null
+     * @throws Exceptions\InvalidTimeRangeString
+     * @throws Exceptions\InvalidTimeString
+     */
+    protected function findNextOpenInFreeTime(Time $time, TimeRange $timeRange, TimeRange &$prevTimeRange = null) {
+        $timeOffRange = $prevTimeRange
+            ?
+            TimeRange::fromString($prevTimeRange->end() . '-' . $timeRange->start())
+            :
+            TimeRange::fromString('00:00-' . $timeRange->start());
 
         if ($timeOffRange->containsTime($time) || $timeOffRange->start()->isSame($time)) {
             return $timeRange->start();
         }
 
         $prevTimeRange = $timeRange;
+
+        return null;
     }
 
-    public function offsetExists($offset): bool
-    {
+    /**
+     * @param mixed $offset
+     * @return bool
+     */
+    public function offsetExists($offset) {
         return isset($this->openingHours[$offset]);
     }
 
-    public function offsetGet($offset)
-    {
+    /**
+     * @param mixed $offset
+     * @return mixed|TimeRange
+     */
+    public function offsetGet($offset) {
         return $this->openingHours[$offset];
     }
 
-    public function offsetSet($offset, $value)
-    {
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     * @throws \Exception
+     */
+    public function offsetSet($offset, $value) {
         throw new \Exception();
     }
 
-    public function offsetUnset($offset)
-    {
+    /**
+     * @param mixed $offset
+     */
+    public function offsetUnset($offset) {
         unset($this->openingHours[$offset]);
     }
 
-    public function count(): int
-    {
+    /**
+     * @return int
+     */
+    public function count() {
         return count($this->openingHours);
     }
 
-    public function getIterator()
-    {
+    /**
+     * @return ArrayIterator|\Traversable
+     */
+    public function getIterator() {
         return new ArrayIterator($this->openingHours);
     }
 
-    public function isEmpty(): bool
-    {
+    /**
+     * @return bool
+     */
+    public function isEmpty() {
         return empty($this->openingHours);
     }
 
-    public function map(callable $callback): array
-    {
+    /**
+     * @param callable $callback
+     * @return array
+     */
+    public function map(callable $callback) {
         return Arr::map($this->openingHours, $callback);
     }
 
-    protected function guardAgainstTimeRangeOverlaps(array $openingHours)
-    {
+    /**
+     * @param array $openingHours
+     * @throws OverlappingTimeRanges
+     */
+    protected function guardAgainstTimeRangeOverlaps(array $openingHours) {
         foreach (Arr::createUniquePairs($openingHours) as $timeRanges) {
+            /* @var $timeRanges TimeRange[] */
             if ($timeRanges[0]->overlaps($timeRanges[1])) {
                 throw OverlappingTimeRanges::forRanges($timeRanges[0], $timeRanges[1]);
             }
         }
     }
 
-    public function __toString()
-    {
+    /**
+     * @return string
+     */
+    public function __toString() {
         $values = [];
         foreach ($this->openingHours as $openingHour) {
-            $values[] = (string) $openingHour;
+            $values[] = (string)$openingHour;
         }
 
         return implode(',', $values);

--- a/src/Time.php
+++ b/src/Time.php
@@ -6,23 +6,29 @@ use DateTime;
 use DateTimeInterface;
 use Spatie\OpeningHours\Exceptions\InvalidTimeString;
 
-class Time
-{
+class Time {
     /** @var int */
     protected $hours;
-
     /** @var int */
     protected $minutes;
 
-    protected function __construct(int $hours, int $minutes)
-    {
-        $this->hours = $hours;
+    /**
+     * Time constructor.
+     * @param $hours
+     * @param $minutes
+     */
+    protected function __construct($hours, $minutes) {
+        $this->hours   = $hours;
         $this->minutes = $minutes;
     }
 
-    public static function fromString(string $string): self
-    {
-        if (! preg_match('/^([0-1][0-9])|(2[0-4]):[0-5][0-9]$/', $string)) {
+    /**
+     * @param string $string
+     * @return static
+     * @throws InvalidTimeString
+     */
+    public static function fromString($string) {
+        if (!preg_match('/^([0-1][0-9])|(2[0-4]):[0-5][0-9]$/', $string)) {
             throw InvalidTimeString::forString($string);
         }
 
@@ -31,18 +37,28 @@ class Time
         return new self($hours, $minutes);
     }
 
-    public static function fromDateTime(DateTimeInterface $dateTime): self
-    {
+    /**
+     * @param DateTimeInterface $dateTime
+     * @return static
+     * @throws InvalidTimeString
+     */
+    public static function fromDateTime(DateTimeInterface $dateTime) {
         return self::fromString($dateTime->format('H:i'));
     }
 
-    public function isSame(self $time): bool
-    {
-        return (string) $this === (string) $time;
+    /**
+     * @param Time $time
+     * @return bool
+     */
+    public function isSame(Time $time) {
+        return (string)$this === (string)$time;
     }
 
-    public function isAfter(self $time): bool
-    {
+    /**
+     * @param Time $time
+     * @return bool
+     */
+    public function isAfter(Time $time) {
         if ($this->isSame($time)) {
             return false;
         }
@@ -54,32 +70,46 @@ class Time
         return $this->hours === $time->hours && $this->minutes >= $time->minutes;
     }
 
-    public function isBefore(self $time): bool
-    {
+    /**
+     * @param Time $time
+     * @return bool
+     */
+    public function isBefore(Time $time) {
         if ($this->isSame($time)) {
             return false;
         }
 
-        return ! $this->isAfter($time);
+        return !$this->isAfter($time);
     }
 
-    public function isSameOrAfter(self $time): bool
-    {
+    /**
+     * @param Time $time
+     * @return bool
+     */
+    public function isSameOrAfter(Time $time) {
         return $this->isSame($time) || $this->isAfter($time);
     }
 
-    public function toDateTime(DateTime $date = null): DateTime
-    {
-        return ($date ?? new DateTime('1970-01-01 00:00:00'))->setTime($this->hours, $this->minutes);
+    /**
+     * @param DateTime|null $date
+     * @return DateTime|false
+     */
+    public function toDateTime(DateTime $date = null) {
+        return ($date ?: new DateTime('1970-01-01 00:00:00'))->setTime($this->hours, $this->minutes);
     }
 
-    public function format(string $format = 'H:i'): string
-    {
+    /**
+     * @param string $format
+     * @return string
+     */
+    public function format($format = 'H:i') {
         return $this->toDateTime()->format($format);
     }
 
-    public function __toString(): string
-    {
+    /**
+     * @return string
+     */
+    public function __toString() {
         return $this->format();
     }
 }

--- a/src/Time.php
+++ b/src/Time.php
@@ -6,7 +6,8 @@ use DateTime;
 use DateTimeInterface;
 use Spatie\OpeningHours\Exceptions\InvalidTimeString;
 
-class Time {
+class Time
+{
     /** @var int */
     protected $hours;
     /** @var int */
@@ -17,9 +18,20 @@ class Time {
      * @param $hours
      * @param $minutes
      */
-    protected function __construct($hours, $minutes) {
-        $this->hours   = $hours;
+    protected function __construct($hours, $minutes)
+    {
+        $this->hours = $hours;
         $this->minutes = $minutes;
+    }
+
+    /**
+     * @param DateTimeInterface $dateTime
+     * @return static
+     * @throws InvalidTimeString
+     */
+    public static function fromDateTime(DateTimeInterface $dateTime)
+    {
+        return self::fromString($dateTime->format('H:i'));
     }
 
     /**
@@ -27,7 +39,8 @@ class Time {
      * @return static
      * @throws InvalidTimeString
      */
-    public static function fromString($string) {
+    public static function fromString($string)
+    {
         if (!preg_match('/^([0-1][0-9])|(2[0-4]):[0-5][0-9]$/', $string)) {
             throw InvalidTimeString::forString($string);
         }
@@ -38,19 +51,24 @@ class Time {
     }
 
     /**
-     * @param DateTimeInterface $dateTime
-     * @return static
-     * @throws InvalidTimeString
+     * @param Time $time
+     * @return bool
      */
-    public static function fromDateTime(DateTimeInterface $dateTime) {
-        return self::fromString($dateTime->format('H:i'));
+    public function isBefore(Time $time)
+    {
+        if ($this->isSame($time)) {
+            return false;
+        }
+
+        return !$this->isAfter($time);
     }
 
     /**
      * @param Time $time
      * @return bool
      */
-    public function isSame(Time $time) {
+    public function isSame(Time $time)
+    {
         return (string)$this === (string)$time;
     }
 
@@ -58,7 +76,8 @@ class Time {
      * @param Time $time
      * @return bool
      */
-    public function isAfter(Time $time) {
+    public function isAfter(Time $time)
+    {
         if ($this->isSame($time)) {
             return false;
         }
@@ -74,42 +93,34 @@ class Time {
      * @param Time $time
      * @return bool
      */
-    public function isBefore(Time $time) {
-        if ($this->isSame($time)) {
-            return false;
-        }
-
-        return !$this->isAfter($time);
-    }
-
-    /**
-     * @param Time $time
-     * @return bool
-     */
-    public function isSameOrAfter(Time $time) {
+    public function isSameOrAfter(Time $time)
+    {
         return $this->isSame($time) || $this->isAfter($time);
     }
 
     /**
-     * @param DateTime|null $date
-     * @return DateTime|false
+     * @return string
      */
-    public function toDateTime(DateTime $date = null) {
-        return ($date ?: new DateTime('1970-01-01 00:00:00'))->setTime($this->hours, $this->minutes);
+    public function __toString()
+    {
+        return $this->format();
     }
 
     /**
      * @param string $format
      * @return string
      */
-    public function format($format = 'H:i') {
+    public function format($format = 'H:i')
+    {
         return $this->toDateTime()->format($format);
     }
 
     /**
-     * @return string
+     * @param DateTime|null $date
+     * @return DateTime|false
      */
-    public function __toString() {
-        return $this->format();
+    public function toDateTime(DateTime $date = null)
+    {
+        return ($date ?: new DateTime('1970-01-01 00:00:00'))->setTime($this->hours, $this->minutes);
     }
 }

--- a/src/TimeRange.php
+++ b/src/TimeRange.php
@@ -4,22 +4,29 @@ namespace Spatie\OpeningHours;
 
 use Spatie\OpeningHours\Exceptions\InvalidTimeRangeString;
 
-class TimeRange
-{
+class TimeRange {
     /** @var \Spatie\OpeningHours\Time */
     protected $start;
-
     /** @var \Spatie\OpeningHours\Time */
     protected $end;
 
-    protected function __construct(Time $start, Time $end)
-    {
+    /**
+     * TimeRange constructor.
+     * @param Time $start
+     * @param Time $end
+     */
+    protected function __construct(Time $start, Time $end) {
         $this->start = $start;
-        $this->end = $end;
+        $this->end   = $end;
     }
 
-    public static function fromString(string $string): self
-    {
+    /**
+     * @param string $string
+     * @return static
+     * @throws Exceptions\InvalidTimeString
+     * @throws InvalidTimeRangeString
+     */
+    public static function fromString($string) {
         $times = explode('-', $string);
 
         if (count($times) !== 2) {
@@ -29,23 +36,32 @@ class TimeRange
         return new self(Time::fromString($times[0]), Time::fromString($times[1]));
     }
 
-    public function start(): Time
-    {
+    /**
+     * @return Time
+     */
+    public function start() {
         return $this->start;
     }
 
-    public function end(): Time
-    {
+    /**
+     * @return Time
+     */
+    public function end() {
         return $this->end;
     }
 
-    public function spillsOverToNextDay(): bool
-    {
+    /**
+     * @return bool
+     */
+    public function spillsOverToNextDay() {
         return $this->end->isBefore($this->start);
     }
 
-    public function containsTime(Time $time): bool
-    {
+    /**
+     * @param Time $time
+     * @return bool
+     */
+    public function containsTime(Time $time) {
         if ($this->spillsOverToNextDay()) {
             if ($time->isAfter($this->start)) {
                 return $time->isAfter($this->end);
@@ -57,18 +73,27 @@ class TimeRange
         return $time->isSameOrAfter($this->start) && $time->isBefore($this->end);
     }
 
-    public function overlaps(self $timeRange): bool
-    {
+    /**
+     * @param TimeRange $timeRange
+     * @return bool
+     */
+    public function overlaps(TimeRange $timeRange) {
         return $this->containsTime($timeRange->start) || $this->containsTime($timeRange->end);
     }
 
-    public function format(string $timeFormat = 'H:i', string $rangeFormat = '%s-%s'): string
-    {
+    /**
+     * @param string $timeFormat
+     * @param string $rangeFormat
+     * @return string
+     */
+    public function format($timeFormat = 'H:i', $rangeFormat = '%s-%s') {
         return sprintf($rangeFormat, $this->start->format($timeFormat), $this->end->format($timeFormat));
     }
 
-    public function __toString(): string
-    {
+    /**
+     * @return string
+     */
+    public function __toString() {
         return $this->format();
     }
 }

--- a/src/TimeRange.php
+++ b/src/TimeRange.php
@@ -4,7 +4,8 @@ namespace Spatie\OpeningHours;
 
 use Spatie\OpeningHours\Exceptions\InvalidTimeRangeString;
 
-class TimeRange {
+class TimeRange
+{
     /** @var \Spatie\OpeningHours\Time */
     protected $start;
     /** @var \Spatie\OpeningHours\Time */
@@ -15,9 +16,10 @@ class TimeRange {
      * @param Time $start
      * @param Time $end
      */
-    protected function __construct(Time $start, Time $end) {
+    protected function __construct(Time $start, Time $end)
+    {
         $this->start = $start;
-        $this->end   = $end;
+        $this->end = $end;
     }
 
     /**
@@ -26,7 +28,8 @@ class TimeRange {
      * @throws Exceptions\InvalidTimeString
      * @throws InvalidTimeRangeString
      */
-    public static function fromString($string) {
+    public static function fromString($string)
+    {
         $times = explode('-', $string);
 
         if (count($times) !== 2) {
@@ -39,29 +42,34 @@ class TimeRange {
     /**
      * @return Time
      */
-    public function start() {
+    public function start()
+    {
         return $this->start;
     }
 
     /**
      * @return Time
      */
-    public function end() {
+    public function end()
+    {
         return $this->end;
     }
 
     /**
+     * @param TimeRange $timeRange
      * @return bool
      */
-    public function spillsOverToNextDay() {
-        return $this->end->isBefore($this->start);
+    public function overlaps(TimeRange $timeRange)
+    {
+        return $this->containsTime($timeRange->start) || $this->containsTime($timeRange->end);
     }
 
     /**
      * @param Time $time
      * @return bool
      */
-    public function containsTime(Time $time) {
+    public function containsTime(Time $time)
+    {
         if ($this->spillsOverToNextDay()) {
             if ($time->isAfter($this->start)) {
                 return $time->isAfter($this->end);
@@ -74,11 +82,19 @@ class TimeRange {
     }
 
     /**
-     * @param TimeRange $timeRange
      * @return bool
      */
-    public function overlaps(TimeRange $timeRange) {
-        return $this->containsTime($timeRange->start) || $this->containsTime($timeRange->end);
+    public function spillsOverToNextDay()
+    {
+        return $this->end->isBefore($this->start);
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->format();
     }
 
     /**
@@ -86,14 +102,8 @@ class TimeRange {
      * @param string $rangeFormat
      * @return string
      */
-    public function format($timeFormat = 'H:i', $rangeFormat = '%s-%s') {
+    public function format($timeFormat = 'H:i', $rangeFormat = '%s-%s')
+    {
         return sprintf($rangeFormat, $this->start->format($timeFormat), $this->end->format($timeFormat));
-    }
-
-    /**
-     * @return string
-     */
-    public function __toString() {
-        return $this->format();
     }
 }

--- a/tests/OpeningHoursFillTest.php
+++ b/tests/OpeningHoursFillTest.php
@@ -46,6 +46,32 @@ class OpeningHoursFillTest extends TestCase
         $this->assertCount(0, $openingHours->forDate(new DateTime('2016-09-26 11:00:00')));
     }
 
+    /**
+     * @test
+     */
+    public function it_can_parse_osm_strings() {
+        $openingHours = OpeningHours::fromOsmString('Mo-Fr 08:00-12:00,13:30-17:30; Aug 01 off');
+
+        $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('monday')[0]);
+        $this->assertEquals((string) $openingHours->forDay('monday')[0], '08:00-12:00');
+        $this->assertEquals((string) $openingHours->forDay('monday')[1], '13:30-17:30');
+        $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('tuesday')[0]);
+        $this->assertEquals((string) $openingHours->forDay('tuesday')[0], '08:00-12:00');
+        $this->assertEquals((string) $openingHours->forDay('tuesday')[1], '13:30-17:30');
+        $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('wednesday')[0]);
+        $this->assertEquals((string) $openingHours->forDay('wednesday')[0], '08:00-12:00');
+        $this->assertEquals((string) $openingHours->forDay('wednesday')[1], '13:30-17:30');
+        $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('thursday')[0]);
+        $this->assertEquals((string) $openingHours->forDay('thursday')[0], '08:00-12:00');
+        $this->assertEquals((string) $openingHours->forDay('thursday')[1], '13:30-17:30');
+        $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('friday')[0]);
+        $this->assertEquals((string) $openingHours->forDay('friday')[0], '08:00-12:00');
+        $this->assertEquals((string) $openingHours->forDay('friday')[1], '13:30-17:30');
+
+//        var_dump($openingHours->exceptions(), $openingHours->forDate(new DateTime('2018-08-01 11:00:00')));
+        $this->assertCount(0, $openingHours->forDate(new DateTime('2018-08-01 11:00:00')));
+    }
+
     /** @test */
     public function it_can_handle_empty_input()
     {

--- a/tests/OpeningHoursFillTest.php
+++ b/tests/OpeningHoursFillTest.php
@@ -3,12 +3,12 @@
 namespace Spatie\OpeningHours\Test;
 
 use DateTime;
-use Spatie\OpeningHours\Day;
 use PHPUnit\Framework\TestCase;
-use Spatie\OpeningHours\TimeRange;
-use Spatie\OpeningHours\OpeningHours;
+use Spatie\OpeningHours\Day;
 use Spatie\OpeningHours\Exceptions\InvalidDate;
 use Spatie\OpeningHours\Exceptions\InvalidDayName;
+use Spatie\OpeningHours\OpeningHours;
+use Spatie\OpeningHours\TimeRange;
 
 class OpeningHoursFillTest extends TestCase
 {
@@ -27,21 +27,21 @@ class OpeningHoursFillTest extends TestCase
         ]);
 
         $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('monday')[0]);
-        $this->assertEquals((string) $openingHours->forDay('monday')[0], '09:00-18:00');
+        $this->assertEquals((string)$openingHours->forDay('monday')[0], '09:00-18:00');
 
         $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('tuesday')[0]);
-        $this->assertEquals((string) $openingHours->forDay('tuesday')[0], '09:00-18:00');
+        $this->assertEquals((string)$openingHours->forDay('tuesday')[0], '09:00-18:00');
 
         $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('wednesday')[0]);
-        $this->assertEquals((string) $openingHours->forDay('wednesday')[0], '09:00-12:00');
+        $this->assertEquals((string)$openingHours->forDay('wednesday')[0], '09:00-12:00');
 
         $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('wednesday')[1]);
-        $this->assertEquals((string) $openingHours->forDay('wednesday')[1], '14:00-18:00');
+        $this->assertEquals((string)$openingHours->forDay('wednesday')[1], '14:00-18:00');
 
         $this->assertCount(0, $openingHours->forDay('thursday'));
 
         $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('friday')[0]);
-        $this->assertEquals((string) $openingHours->forDay('friday')[0], '09:00-20:00');
+        $this->assertEquals((string)$openingHours->forDay('friday')[0], '09:00-20:00');
 
         $this->assertCount(0, $openingHours->forDate(new DateTime('2016-09-26 11:00:00')));
     }
@@ -49,24 +49,25 @@ class OpeningHoursFillTest extends TestCase
     /**
      * @test
      */
-    public function it_can_parse_osm_strings() {
+    public function it_can_parse_osm_strings()
+    {
         $openingHours = OpeningHours::fromOsmString('Mo-Fr 08:00-12:00,13:30-17:30; Aug 01 off');
 
         $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('monday')[0]);
-        $this->assertEquals((string) $openingHours->forDay('monday')[0], '08:00-12:00');
-        $this->assertEquals((string) $openingHours->forDay('monday')[1], '13:30-17:30');
+        $this->assertEquals((string)$openingHours->forDay('monday')[0], '08:00-12:00');
+        $this->assertEquals((string)$openingHours->forDay('monday')[1], '13:30-17:30');
         $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('tuesday')[0]);
-        $this->assertEquals((string) $openingHours->forDay('tuesday')[0], '08:00-12:00');
-        $this->assertEquals((string) $openingHours->forDay('tuesday')[1], '13:30-17:30');
+        $this->assertEquals((string)$openingHours->forDay('tuesday')[0], '08:00-12:00');
+        $this->assertEquals((string)$openingHours->forDay('tuesday')[1], '13:30-17:30');
         $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('wednesday')[0]);
-        $this->assertEquals((string) $openingHours->forDay('wednesday')[0], '08:00-12:00');
-        $this->assertEquals((string) $openingHours->forDay('wednesday')[1], '13:30-17:30');
+        $this->assertEquals((string)$openingHours->forDay('wednesday')[0], '08:00-12:00');
+        $this->assertEquals((string)$openingHours->forDay('wednesday')[1], '13:30-17:30');
         $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('thursday')[0]);
-        $this->assertEquals((string) $openingHours->forDay('thursday')[0], '08:00-12:00');
-        $this->assertEquals((string) $openingHours->forDay('thursday')[1], '13:30-17:30');
+        $this->assertEquals((string)$openingHours->forDay('thursday')[0], '08:00-12:00');
+        $this->assertEquals((string)$openingHours->forDay('thursday')[1], '13:30-17:30');
         $this->assertInstanceOf(TimeRange::class, $openingHours->forDay('friday')[0]);
-        $this->assertEquals((string) $openingHours->forDay('friday')[0], '08:00-12:00');
-        $this->assertEquals((string) $openingHours->forDay('friday')[1], '13:30-17:30');
+        $this->assertEquals((string)$openingHours->forDay('friday')[0], '08:00-12:00');
+        $this->assertEquals((string)$openingHours->forDay('friday')[1], '13:30-17:30');
 
 //        var_dump($openingHours->exceptions(), $openingHours->forDate(new DateTime('2018-08-01 11:00:00')));
         $this->assertCount(0, $openingHours->forDate(new DateTime('2018-08-01 11:00:00')));
@@ -89,13 +90,13 @@ class OpeningHoursFillTest extends TestCase
             'Monday' => ['09:00-18:00'],
         ]);
 
-        $this->assertEquals((string) $openingHours->forDay('monday')[0], '09:00-18:00');
+        $this->assertEquals((string)$openingHours->forDay('monday')[0], '09:00-18:00');
 
         $openingHours = OpeningHours::create([
             'monday' => ['09:00-18:00'],
         ]);
 
-        $this->assertEquals((string) $openingHours->forDay('Monday')[0], '09:00-18:00');
+        $this->assertEquals((string)$openingHours->forDay('Monday')[0], '09:00-18:00');
     }
 
     /** @test */

--- a/tests/OpeningHoursForDayTest.php
+++ b/tests/OpeningHoursForDayTest.php
@@ -2,11 +2,11 @@
 
 namespace Spatie\OpeningHours\Test;
 
-use Spatie\OpeningHours\Time;
 use PHPUnit\Framework\TestCase;
-use Spatie\OpeningHours\TimeRange;
-use Spatie\OpeningHours\OpeningHoursForDay;
 use Spatie\OpeningHours\Exceptions\OverlappingTimeRanges;
+use Spatie\OpeningHours\OpeningHoursForDay;
+use Spatie\OpeningHours\Time;
+use Spatie\OpeningHours\TimeRange;
 
 class OpeningHoursForDayTest extends TestCase
 {
@@ -18,10 +18,10 @@ class OpeningHoursForDayTest extends TestCase
         $this->assertCount(2, $openingHoursForDay);
 
         $this->assertInstanceOf(TimeRange::class, $openingHoursForDay[0]);
-        $this->assertEquals('09:00-12:00', (string) $openingHoursForDay[0]);
+        $this->assertEquals('09:00-12:00', (string)$openingHoursForDay[0]);
 
         $this->assertInstanceOf(TimeRange::class, $openingHoursForDay[1]);
-        $this->assertEquals('13:00-18:00', (string) $openingHoursForDay[1]);
+        $this->assertEquals('13:00-18:00', (string)$openingHoursForDay[1]);
     }
 
     /** @test */
@@ -47,7 +47,7 @@ class OpeningHoursForDayTest extends TestCase
     {
         $openingHoursForDay = OpeningHoursForDay::fromStrings(['09:00-12:00', '13:00-18:00']);
 
-        $this->assertEquals('09:00-12:00,13:00-18:00', (string) $openingHoursForDay);
+        $this->assertEquals('09:00-12:00,13:00-18:00', (string)$openingHoursForDay);
     }
 
     /** @test */

--- a/tests/OpeningHoursStructuredDataTest.php
+++ b/tests/OpeningHoursStructuredDataTest.php
@@ -28,33 +28,39 @@ class OpeningHoursStructuredDataTest extends TestCase
                 'dayOfWeek' => 'Monday',
                 'opens' => '09:00',
                 'closes' => '18:00',
-            ], [
+            ],
+            [
                 '@type' => 'OpeningHoursSpecification',
                 'dayOfWeek' => 'Tuesday',
                 'opens' => '09:00',
                 'closes' => '18:00',
-            ], [
+            ],
+            [
                 '@type' => 'OpeningHoursSpecification',
                 'dayOfWeek' => 'Wednesday',
                 'opens' => '09:00',
                 'closes' => '12:00',
-            ], [
+            ],
+            [
                 '@type' => 'OpeningHoursSpecification',
                 'dayOfWeek' => 'Wednesday',
                 'opens' => '14:00',
                 'closes' => '18:00',
-            ], [
+            ],
+            [
                 '@type' => 'OpeningHoursSpecification',
                 'dayOfWeek' => 'Friday',
                 'opens' => '09:00',
                 'closes' => '20:00',
-            ], [
+            ],
+            [
                 '@type' => 'OpeningHoursSpecification',
                 'opens' => '09:00',
                 'closes' => '12:00',
                 'validFrom' => '2016-09-26',
                 'validThrough' => '2016-09-26',
-            ], [
+            ],
+            [
                 '@type' => 'OpeningHoursSpecification',
                 'opens' => '00:00',
                 'closes' => '00:00',

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -19,7 +19,7 @@ class OpeningHoursTest extends TestCase
         $openingHoursForWeek = $openingHours->forWeek();
 
         $this->assertCount(7, $openingHoursForWeek);
-        $this->assertEquals('09:00-18:00', (string) $openingHoursForWeek['monday'][0]);
+        $this->assertEquals('09:00-18:00', (string)$openingHoursForWeek['monday'][0]);
         $this->assertCount(0, $openingHoursForWeek['tuesday']);
         $this->assertCount(0, $openingHoursForWeek['wednesday']);
         $this->assertCount(0, $openingHoursForWeek['thursday']);
@@ -278,15 +278,22 @@ class OpeningHoursTest extends TestCase
         $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 08:00')));
         $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 06:00')));
 
-        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 06:00', new DateTimeZone('Europe/Amsterdam'))));
-        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:00', new DateTimeZone('Europe/Amsterdam'))));
-        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 17:59', new DateTimeZone('Europe/Amsterdam'))));
+        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 06:00',
+            new DateTimeZone('Europe/Amsterdam'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:00',
+            new DateTimeZone('Europe/Amsterdam'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 17:59',
+            new DateTimeZone('Europe/Amsterdam'))));
 
-        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-11-14 17:59', new DateTimeZone('Europe/Amsterdam'))));
-        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-11-14 12:59', new DateTimeZone('Europe/Amsterdam'))));
+        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-11-14 17:59',
+            new DateTimeZone('Europe/Amsterdam'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-11-14 12:59',
+            new DateTimeZone('Europe/Amsterdam'))));
 
-        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-11-14 15:59', new DateTimeZone('America/Denver'))));
-        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:59', new DateTimeZone('America/Denver'))));
+        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-11-14 15:59',
+            new DateTimeZone('America/Denver'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:59',
+            new DateTimeZone('America/Denver'))));
 
         date_default_timezone_set('America/Denver');
         $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:59')));
@@ -387,7 +394,7 @@ class OpeningHoursTest extends TestCase
         $openingHoursForWeek = $openingHours->forWeek();
 
         $this->assertCount(7, $openingHoursForWeek);
-        $this->assertEquals('00:00-16:00', (string) $openingHoursForWeek['monday'][0]);
+        $this->assertEquals('00:00-16:00', (string)$openingHoursForWeek['monday'][0]);
         $this->assertCount(0, $openingHoursForWeek['tuesday']);
         $this->assertCount(0, $openingHoursForWeek['wednesday']);
         $this->assertCount(0, $openingHoursForWeek['thursday']);

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -275,7 +275,7 @@ class OpeningHoursTest extends TestCase
 
         $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 10:00')));
         $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 15:59')));
-        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 08:00')));
+        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 08:00')));
         $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 06:00')));
 
         $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 06:00', new DateTimeZone('Europe/Amsterdam'))));

--- a/tests/TimeRangeTest.php
+++ b/tests/TimeRangeTest.php
@@ -2,17 +2,17 @@
 
 namespace Spatie\OpeningHours\Test;
 
-use Spatie\OpeningHours\Time;
 use PHPUnit\Framework\TestCase;
-use Spatie\OpeningHours\TimeRange;
 use Spatie\OpeningHours\Exceptions\InvalidTimeRangeString;
+use Spatie\OpeningHours\Time;
+use Spatie\OpeningHours\TimeRange;
 
 class TimeRangeTest extends TestCase
 {
     /** @test */
     public function it_can_be_created_from_a_string()
     {
-        $this->assertEquals('16:00-18:00', (string) TimeRange::fromString('16:00-18:00'));
+        $this->assertEquals('16:00-18:00', (string)TimeRange::fromString('16:00-18:00'));
     }
 
     /** @test */

--- a/tests/TimeTest.php
+++ b/tests/TimeTest.php
@@ -3,16 +3,16 @@
 namespace Spatie\OpeningHours\Test;
 
 use DateTime;
-use Spatie\OpeningHours\Time;
 use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\Exceptions\InvalidTimeString;
+use Spatie\OpeningHours\Time;
 
 class TimeTest extends TestCase
 {
     /** @test */
     public function it_can_be_created_from_a_string()
     {
-        $this->assertEquals('16:00', (string) Time::fromString('16:00'));
+        $this->assertEquals('16:00', (string)Time::fromString('16:00'));
     }
 
     /** @test */
@@ -28,7 +28,7 @@ class TimeTest extends TestCase
     {
         $dateTime = new DateTime('2016-09-27 16:00:00');
 
-        $this->assertEquals('16:00', (string) Time::fromDateTime($dateTime));
+        $this->assertEquals('16:00', (string)Time::fromDateTime($dateTime));
     }
 
     /** @test */
@@ -76,7 +76,7 @@ class TimeTest extends TestCase
     {
         $dateTime = date_create_immutable('2012-11-06 13:25:59.123456');
 
-        $this->assertEquals('13:25', (string) Time::fromDateTime($dateTime));
+        $this->assertEquals('13:25', (string)Time::fromDateTime($dateTime));
     }
 
     /** @test */


### PR DESCRIPTION
There is a [standard by Open Street Maps](https://wiki.openstreetmap.org/wiki/Key:opening_hours) how to handle opening hours. It is also accepted by google (e.g. [https://schema.org/openingHours](https://schema.org/openingHours)). I added (at least some trivial) parsing functionality for this syntax.

I think it's a bit early to only develop for php 7. Php 5.6 is still supported (until end of the year), so I changed the code to run under 5.6 too.