### PR TITLE
#63 isOpenAt returns false (isClosedAt returns true) for the last second of day

### DIFF
--- a/src/TimeRange.php
+++ b/src/TimeRange.php
@@ -47,14 +47,14 @@ class TimeRange
     public function containsTime(Time $time): bool
     {
         if ($this->spillsOverToNextDay()) {
-            if ($time->isAfter($this->start)) {
+            if ($time->isSameOrAfter($this->start)) {
                 return $time->isAfter($this->end);
             }
 
-            return $time->isBefore($this->end);
+            return ! $time->isAfter($this->end);
         }
 
-        return $time->isSameOrAfter($this->start) && $time->isBefore($this->end);
+        return $time->isSameOrAfter($this->start) && ! $time->isAfter($this->end);
     }
 
     public function overlaps(self $timeRange): bool

--- a/tests/OpeningHoursForDayTest.php
+++ b/tests/OpeningHoursForDayTest.php
@@ -39,7 +39,8 @@ class OpeningHoursForDayTest extends TestCase
 
         $this->assertTrue($openingHoursForDay->isOpenAt(Time::fromString('09:00')));
         $this->assertFalse($openingHoursForDay->isOpenAt(Time::fromString('08:00')));
-        $this->assertFalse($openingHoursForDay->isOpenAt(Time::fromString('18:00')));
+        $this->assertTrue($openingHoursForDay->isOpenAt(Time::fromString('18:00')));
+        $this->assertFalse($openingHoursForDay->isOpenAt(Time::fromString('18:01')));
     }
 
     /** @test */

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -324,17 +324,17 @@ class OpeningHoursTest extends TestCase
 
         $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 06:00', new DateTimeZone('Europe/Amsterdam'))));
         $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:00', new DateTimeZone('Europe/Amsterdam'))));
-        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 17:59', new DateTimeZone('Europe/Amsterdam'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 18:00', new DateTimeZone('Europe/Amsterdam'))));
 
         $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-11-14 17:59', new DateTimeZone('Europe/Amsterdam'))));
-        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-11-14 12:59', new DateTimeZone('Europe/Amsterdam'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-11-14 13:00', new DateTimeZone('Europe/Amsterdam'))));
 
         $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-11-14 15:59', new DateTimeZone('America/Denver'))));
-        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:59', new DateTimeZone('America/Denver'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 10:00', new DateTimeZone('America/Denver'))));
 
         date_default_timezone_set('America/Denver');
-        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:59')));
-        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 10:00')));
+        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 10:00')));
+        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 10:01')));
     }
 
     /** @test */

--- a/tests/TimeRangeTest.php
+++ b/tests/TimeRangeTest.php
@@ -44,12 +44,16 @@ class TimeRangeTest extends TestCase
     {
         $this->assertTrue(TimeRange::fromString('16:00-18:00')->containsTime(Time::fromString('16:00')));
         $this->assertTrue(TimeRange::fromString('16:00-18:00')->containsTime(Time::fromString('17:00')));
-        $this->assertFalse(TimeRange::fromString('16:00-18:00')->containsTime(Time::fromString('18:00')));
+        $this->assertTrue(TimeRange::fromString('16:00-18:00')->containsTime(Time::fromString('18:00')));
+        $this->assertFalse(TimeRange::fromString('16:00-18:00')->containsTime(Time::fromString('18:01')));
 
         $this->assertTrue(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('00:30')));
         $this->assertTrue(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('22:00')));
         $this->assertFalse(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('17:00')));
         $this->assertFalse(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('02:00')));
+
+        $this->assertTrue(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('18:00')));
+        $this->assertTrue(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('01:00')));
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #63 where last second of opening timerange was not considered as open
Fixes bug where overspilling timerange did not contain starting time. 