### PR TITLE
FIX: Overspilling timerange does not contain start time

### DIFF
--- a/src/TimeRange.php
+++ b/src/TimeRange.php
@@ -47,7 +47,7 @@ class TimeRange
     public function containsTime(Time $time): bool
     {
         if ($this->spillsOverToNextDay()) {
-            if ($time->isAfter($this->start)) {
+            if ($time->isSameOrAfter($this->start)) {
                 return $time->isAfter($this->end);
             }
 

--- a/tests/TimeRangeTest.php
+++ b/tests/TimeRangeTest.php
@@ -50,6 +50,10 @@ class TimeRangeTest extends TestCase
         $this->assertTrue(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('22:00')));
         $this->assertFalse(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('17:00')));
         $this->assertFalse(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('02:00')));
+
+        $this->assertTrue(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('18:00')));
+        $this->assertTrue(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('00:59')));
+        $this->assertFalse(TimeRange::fromString('18:00-01:00')->containsTime(Time::fromString('01:00')));
     }
 
     /** @test */


### PR DESCRIPTION
If timerange spills over to next day, then `containsTime()` returns false for start time