### PR TITLE
Fix next methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,5 @@
     },
     "config": {
         "sort-packages": true
-  }
+    }
 }

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -152,7 +152,7 @@ class OpeningHours
     }
 
     /**
-     * @TODO This should return DateTimeInterface on next major release
+     * @todo This should return DateTimeInterface on next major release
      */
     public function nextOpen(DateTimeInterface $dateTime): DateTime
     {
@@ -180,7 +180,7 @@ class OpeningHours
     }
 
     /**
-     * @TODO This should return DateTimeInterface on next major release
+     * @todo This should return DateTimeInterface on next major release
      */
     public function nextClose(DateTimeInterface $dateTime): DateTime
     {

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -4,6 +4,7 @@ namespace Spatie\OpeningHours;
 
 use DateTime;
 use DateTimeZone;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Spatie\OpeningHours\Helpers\Arr;
 use Spatie\OpeningHours\Exceptions\Exception;
@@ -150,13 +151,20 @@ class OpeningHours
         return $this->isClosedAt(new DateTime());
     }
 
+    /**
+     * @TODO This should return DateTimeInterface on next major release
+     */
     public function nextOpen(DateTimeInterface $dateTime): DateTime
     {
+        if (! ($dateTime instanceof DateTimeImmutable)) {
+            $dateTime = clone $dateTime;
+        }
+
         $openingHoursForDay = $this->forDate($dateTime);
         $nextOpen = $openingHoursForDay->nextOpen(Time::fromDateTime($dateTime));
 
-        while ($nextOpen == false) {
-            $dateTime
+        while ($nextOpen === false) {
+            $dateTime = $dateTime
                 ->modify('+1 day')
                 ->setTime(0, 0, 0);
 
@@ -166,18 +174,25 @@ class OpeningHours
         }
 
         $nextDateTime = $nextOpen->toDateTime();
-        $dateTime->setTime($nextDateTime->format('G'), $nextDateTime->format('i'), 0);
+        $dateTime = $dateTime->setTime($nextDateTime->format('G'), $nextDateTime->format('i'), 0);
 
         return $dateTime;
     }
 
+    /**
+     * @TODO This should return DateTimeInterface on next major release
+     */
     public function nextClose(DateTimeInterface $dateTime): DateTime
     {
+        if (! ($dateTime instanceof DateTimeImmutable)) {
+            $dateTime = clone $dateTime;
+        }
+
         $openingHoursForDay = $this->forDate($dateTime);
         $nextClose = $openingHoursForDay->nextClose(Time::fromDateTime($dateTime));
 
-        while ($nextClose == false) {
-            $dateTime
+        while ($nextClose === false) {
+            $dateTime = $dateTime
                 ->modify('+1 day')
                 ->setTime(0, 0, 0);
 
@@ -187,7 +202,7 @@ class OpeningHours
         }
 
         $nextDateTime = $nextClose->toDateTime();
-        $dateTime->setTime($nextDateTime->format('G'), $nextDateTime->format('i'), 0);
+        $dateTime = $dateTime->setTime($nextDateTime->format('G'), $nextDateTime->format('i'), 0);
 
         return $dateTime;
     }

--- a/src/OpeningHoursForDay.php
+++ b/src/OpeningHoursForDay.php
@@ -44,10 +44,14 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
     {
         foreach ($this->openingHours as $timeRange) {
             if ($nextOpen = $this->findNextOpenInWorkingHours($time, $timeRange)) {
+                reset($timeRange);
+
                 return $nextOpen;
             }
 
             if ($nextOpen = $this->findNextOpenInFreeTime($time, $timeRange)) {
+                reset($timeRange);
+
                 return $nextOpen;
             }
         }
@@ -59,10 +63,14 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
     {
         foreach ($this->openingHours as $timeRange) {
             if ($nextClose = $this->findNextCloseInWorkingHours($time, $timeRange)) {
+                reset($timeRange);
+
                 return $nextClose;
             }
 
             if ($nextClose = $this->findNextCloseInFreeTime($time, $timeRange)) {
+                reset($timeRange);
+
                 return $nextClose;
             }
         }

--- a/src/Time.php
+++ b/src/Time.php
@@ -85,7 +85,7 @@ class Time
     }
 
     /**
-     * @TODO This should take and return DateTimeInterface on next major release
+     * @todo This should take and return DateTimeInterface on next major release
      */
     public function toDateTime(DateTime $date = null): DateTime
     {

--- a/src/Time.php
+++ b/src/Time.php
@@ -3,6 +3,7 @@
 namespace Spatie\OpeningHours;
 
 use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Spatie\OpeningHours\Exceptions\InvalidTimeString;
 
@@ -83,9 +84,16 @@ class Time
         return $this->toDateTime()->diff($time->toDateTime());
     }
 
+    /**
+     * @TODO This should take and return DateTimeInterface on next major release
+     */
     public function toDateTime(DateTime $date = null): DateTime
     {
-        $date = $date ? (clone $date) : new DateTime('1970-01-01 00:00:00');
+        if (! $date) {
+            $date = new DateTime('1970-01-01 00:00:00');
+        } elseif (! ($date instanceof DateTimeImmutable)) {
+            $date = clone $date;
+        }
 
         return $date->setTime($this->hours, $this->minutes);
     }

--- a/tests/OpeningHoursFillTest.php
+++ b/tests/OpeningHoursFillTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\OpeningHours\Test;
 
 use DateTime;
+use DateTimeImmutable;
 use Spatie\OpeningHours\Day;
 use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\TimeRange;
@@ -44,6 +45,7 @@ class OpeningHoursFillTest extends TestCase
         $this->assertEquals((string) $openingHours->forDay('friday')[0], '09:00-20:00');
 
         $this->assertCount(0, $openingHours->forDate(new DateTime('2016-09-26 11:00:00')));
+        $this->assertCount(0, $openingHours->forDate(new DateTimeImmutable('2016-09-26 11:00:00')));
     }
 
     /** @test */

--- a/tests/OpeningHoursForDayTest.php
+++ b/tests/OpeningHoursForDayTest.php
@@ -71,7 +71,7 @@ class OpeningHoursForDayTest extends TestCase
     }
 
     /** @test */
-    public function ic_can_get_iterator()
+    public function it_can_get_iterator()
     {
         $openingHoursForDay = OpeningHoursForDay::fromStrings(['09:00-12:00', '13:00-18:00']);
 

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -4,6 +4,7 @@ namespace Spatie\OpeningHours\Test;
 
 use DateTime;
 use DateTimeZone;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\OpeningHours;
 
@@ -131,6 +132,14 @@ class OpeningHoursTest extends TestCase
         $this->assertEquals('09:00-18:00', $openingHoursForMonday1909[0]);
 
         $this->assertCount(0, $openingHoursForMonday2609);
+
+        $openingHoursForMonday1909 = $openingHours->forDate(new DateTimeImmutable('2016-09-19 00:00:00'));
+        $openingHoursForMonday2609 = $openingHours->forDate(new DateTimeImmutable('2016-09-26 00:00:00'));
+
+        $this->assertCount(1, $openingHoursForMonday1909);
+        $this->assertEquals('09:00-18:00', $openingHoursForMonday1909[0]);
+
+        $this->assertCount(0, $openingHoursForMonday2609);
     }
 
     /** @test */
@@ -144,6 +153,10 @@ class OpeningHoursTest extends TestCase
         $this->assertTrue($openingHours->isOpenAt($shouldBeOpen));
         $this->assertFalse($openingHours->isClosedAt($shouldBeOpen));
 
+        $shouldBeOpen = new DateTimeImmutable('2016-09-26 11:00:00');
+        $this->assertTrue($openingHours->isOpenAt($shouldBeOpen));
+        $this->assertFalse($openingHours->isClosedAt($shouldBeOpen));
+
         $shouldBeOpenAlternativeDate = date_create_immutable('2016-09-26 11:12:13.123456');
         $this->assertTrue($openingHours->isOpenAt($shouldBeOpenAlternativeDate));
         $this->assertFalse($openingHours->isClosedAt($shouldBeOpenAlternativeDate));
@@ -152,7 +165,15 @@ class OpeningHoursTest extends TestCase
         $this->assertFalse($openingHours->isOpenAt($shouldBeClosedBecauseOfTime));
         $this->assertTrue($openingHours->isClosedAt($shouldBeClosedBecauseOfTime));
 
+        $shouldBeClosedBecauseOfTime = new DateTimeImmutable('2016-09-26 20:00:00');
+        $this->assertFalse($openingHours->isOpenAt($shouldBeClosedBecauseOfTime));
+        $this->assertTrue($openingHours->isClosedAt($shouldBeClosedBecauseOfTime));
+
         $shouldBeClosedBecauseOfDay = new DateTime('2016-09-27 11:00:00');
+        $this->assertFalse($openingHours->isOpenAt($shouldBeClosedBecauseOfDay));
+        $this->assertTrue($openingHours->isClosedAt($shouldBeClosedBecauseOfDay));
+
+        $shouldBeClosedBecauseOfDay = new DateTimeImmutable('2016-09-27 11:00:00');
         $this->assertFalse($openingHours->isOpenAt($shouldBeClosedBecauseOfDay));
         $this->assertTrue($openingHours->isClosedAt($shouldBeClosedBecauseOfDay));
     }
@@ -168,6 +189,10 @@ class OpeningHoursTest extends TestCase
         ]);
 
         $shouldBeClosed = new DateTime('2016-09-26 11:00:00');
+        $this->assertFalse($openingHours->isOpenAt($shouldBeClosed));
+        $this->assertTrue($openingHours->isClosedAt($shouldBeClosed));
+
+        $shouldBeClosed = new DateTimeImmutable('2016-09-26 11:00:00');
         $this->assertFalse($openingHours->isOpenAt($shouldBeClosed));
         $this->assertTrue($openingHours->isClosedAt($shouldBeClosed));
     }
@@ -188,11 +213,23 @@ class OpeningHoursTest extends TestCase
         $this->assertFalse($openingHours->isOpenAt($closedOnNewYearDay));
         $this->assertTrue($openingHours->isClosedAt($closedOnNewYearDay));
 
+        $closedOnNewYearDay = new DateTimeImmutable('2017-01-01 11:00:00');
+        $this->assertFalse($openingHours->isOpenAt($closedOnNewYearDay));
+        $this->assertTrue($openingHours->isClosedAt($closedOnNewYearDay));
+
         $closedOnSecondChristmasDay = new DateTime('2025-12-16 12:00:00');
         $this->assertFalse($openingHours->isOpenAt($closedOnSecondChristmasDay));
         $this->assertTrue($openingHours->isClosedAt($closedOnSecondChristmasDay));
 
+        $closedOnSecondChristmasDay = new DateTimeImmutable('2025-12-16 12:00:00');
+        $this->assertFalse($openingHours->isOpenAt($closedOnSecondChristmasDay));
+        $this->assertTrue($openingHours->isClosedAt($closedOnSecondChristmasDay));
+
         $openOnChristmasMorning = new DateTime('2025-12-25 10:00:00');
+        $this->assertTrue($openingHours->isOpenAt($openOnChristmasMorning));
+        $this->assertFalse($openingHours->isClosedAt($openOnChristmasMorning));
+
+        $openOnChristmasMorning = new DateTimeImmutable('2025-12-25 10:00:00');
         $this->assertTrue($openingHours->isOpenAt($openOnChristmasMorning));
         $this->assertFalse($openingHours->isClosedAt($openOnChristmasMorning));
     }
@@ -213,7 +250,15 @@ class OpeningHoursTest extends TestCase
         $this->assertTrue($openingHours->isOpenAt($openOnNewYearDay2018));
         $this->assertFalse($openingHours->isClosedAt($openOnNewYearDay2018));
 
+        $openOnNewYearDay2018 = new DateTimeImmutable('2018-01-01 11:00:00');
+        $this->assertTrue($openingHours->isOpenAt($openOnNewYearDay2018));
+        $this->assertFalse($openingHours->isClosedAt($openOnNewYearDay2018));
+
         $closedOnNewYearDay2019 = new DateTime('2019-01-01 11:00:00');
+        $this->assertFalse($openingHours->isOpenAt($closedOnNewYearDay2019));
+        $this->assertTrue($openingHours->isClosedAt($closedOnNewYearDay2019));
+
+        $closedOnNewYearDay2019 = new DateTimeImmutable('2019-01-01 11:00:00');
         $this->assertFalse($openingHours->isOpenAt($closedOnNewYearDay2019));
         $this->assertTrue($openingHours->isClosedAt($closedOnNewYearDay2019));
     }
@@ -221,6 +266,21 @@ class OpeningHoursTest extends TestCase
     /** @test */
     public function it_can_determine_next_open_hours_from_non_working_date_time()
     {
+        $openingHours = OpeningHours::create([
+            'monday' => ['09:00-11:00', '13:00-19:00'],
+        ]);
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2016-09-26 12:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2016-09-26 13:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+    }
+
+    /** @test */
+    public function it_can_determine_next_open_hours_from_non_working_date_time_immutable()
+    {
+        $this->markTestIncomplete('Not supported in v1.x');
+
         $openingHours = OpeningHours::create([
             'monday' => ['09:00-11:00', '13:00-19:00'],
         ]);
@@ -245,6 +305,21 @@ class OpeningHoursTest extends TestCase
     }
 
     /** @test */
+    public function it_can_determine_next_close_hours_from_non_working_date_time_immutable()
+    {
+        $this->markTestIncomplete('Not supported in v1.x');
+
+        $openingHours = OpeningHours::create([
+            'monday' => ['09:00-11:00', '13:00-19:00'],
+        ]);
+
+        $nextTimeOpen = $openingHours->nextClose(new DateTimeImmutable('2016-09-26 12:00:00'));
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $nextTimeOpen);
+        $this->assertEquals('2016-09-26 19:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+    }
+
+    /** @test */
     public function it_can_determine_next_open_hours_from_working_date_time()
     {
         $openingHours = OpeningHours::create([
@@ -259,6 +334,22 @@ class OpeningHoursTest extends TestCase
     }
 
     /** @test */
+    public function it_can_determine_next_open_hours_from_working_date_time_immutable()
+    {
+        $this->markTestIncomplete('Not supported in v1.x');
+
+        $openingHours = OpeningHours::create([
+            'monday' => ['09:00-11:00', '13:00-19:00'],
+            'tuesday' => ['10:00-11:00', '14:00-19:00'],
+        ]);
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTimeImmutable('2016-09-26 16:00:00'));
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $nextTimeOpen);
+        $this->assertEquals('2016-09-27 10:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+    }
+
+    /** @test */
     public function it_can_determine_next_close_hours_from_working_date_time()
     {
         $openingHours = OpeningHours::create([
@@ -266,10 +357,26 @@ class OpeningHoursTest extends TestCase
             'tuesday' => ['10:00-11:00', '14:00-19:00'],
         ]);
 
-        $nextTimeOpen = $openingHours->nextClose(new DateTime('2016-09-26 16:00:00'));
+        $nextTimeClose = $openingHours->nextClose(new DateTime('2016-09-26 16:00:00'));
 
-        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
-        $this->assertEquals('2016-09-26 19:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+        $this->assertInstanceOf(DateTime::class, $nextTimeClose);
+        $this->assertEquals('2016-09-26 19:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
+    }
+
+    /** @test */
+    public function it_can_determine_next_close_hours_from_working_date_time_immutable()
+    {
+        $this->markTestIncomplete('Not supported in v1.x');
+
+        $openingHours = OpeningHours::create([
+            'monday' => ['09:00-11:00', '13:00-19:00'],
+            'tuesday' => ['10:00-11:00', '14:00-19:00'],
+        ]);
+
+        $nextTimeClose = $openingHours->nextClose(new DateTimeImmutable('2016-09-26 16:00:00'));
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $nextTimeClose);
+        $this->assertEquals('2016-09-26 19:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
     }
 
     /** @test */
@@ -290,6 +397,25 @@ class OpeningHoursTest extends TestCase
     }
 
     /** @test */
+    public function it_can_determine_next_open_hours_from_early_morning_immutable()
+    {
+        $this->markTestIncomplete('Not supported in v1.x');
+
+        $openingHours = OpeningHours::create([
+            'monday' => ['09:00-11:00', '13:00-19:00'],
+            'tuesday' => ['10:00-11:00', '14:00-19:00'],
+            'exceptions' => [
+                '2016-09-26' => [],
+            ],
+        ]);
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTimeImmutable('2016-09-26 04:00:00'));
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $nextTimeOpen);
+        $this->assertEquals('2016-09-27 10:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+    }
+
+    /** @test */
     public function it_can_determine_next_close_hours_from_early_morning()
     {
         $openingHours = OpeningHours::create([
@@ -303,6 +429,25 @@ class OpeningHoursTest extends TestCase
         $nextTimeOpen = $openingHours->nextClose(new DateTime('2016-09-26 04:00:00'));
 
         $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2016-09-27 11:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+    }
+
+    /** @test */
+    public function it_can_determine_next_close_hours_from_early_morning_immutable()
+    {
+        $this->markTestIncomplete('Not supported in v1.x');
+
+        $openingHours = OpeningHours::create([
+            'monday' => ['09:00-11:00', '13:00-19:00'],
+            'tuesday' => ['10:00-11:00', '14:00-19:00'],
+            'exceptions' => [
+                '2016-09-26' => [],
+            ],
+        ]);
+
+        $nextTimeOpen = $openingHours->nextClose(new DateTimeImmutable('2016-09-26 04:00:00'));
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $nextTimeOpen);
         $this->assertEquals('2016-09-27 11:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
     }
 
@@ -332,9 +477,27 @@ class OpeningHoursTest extends TestCase
         $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-11-14 15:59', new DateTimeZone('America/Denver'))));
         $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:59', new DateTimeZone('America/Denver'))));
 
+        $this->assertTrue($openingHours->isOpenAt(new DateTimeImmutable('2016-10-10 10:00')));
+        $this->assertTrue($openingHours->isOpenAt(new DateTimeImmutable('2016-10-10 15:59')));
+        $this->assertTrue($openingHours->isOpenAt(new DateTimeImmutable('2016-10-10 08:00')));
+        $this->assertFalse($openingHours->isOpenAt(new DateTimeImmutable('2016-10-10 06:00')));
+
+        $this->assertFalse($openingHours->isOpenAt(new DateTimeImmutable('2016-10-10 06:00', new DateTimeZone('Europe/Amsterdam'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTimeImmutable('2016-10-10 09:00', new DateTimeZone('Europe/Amsterdam'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTimeImmutable('2016-10-10 17:59', new DateTimeZone('Europe/Amsterdam'))));
+
+        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-11-14 17:59', new DateTimeZone('Europe/Amsterdam'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-11-14 12:59', new DateTimeZone('Europe/Amsterdam'))));
+
+        $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-11-14 15:59', new DateTimeZone('America/Denver'))));
+        $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:59', new DateTimeZone('America/Denver'))));
+
         date_default_timezone_set('America/Denver');
         $this->assertTrue($openingHours->isOpenAt(new DateTime('2016-10-10 09:59')));
         $this->assertFalse($openingHours->isOpenAt(new DateTime('2016-10-10 10:00')));
+
+        $this->assertTrue($openingHours->isOpenAt(new DateTimeImmutable('2016-10-10 09:59')));
+        $this->assertFalse($openingHours->isOpenAt(new DateTimeImmutable('2016-10-10 10:00')));
     }
 
     /** @test */
@@ -419,6 +582,19 @@ class OpeningHoursTest extends TestCase
 
         $nextTimeOpen = $openingHours->nextOpen(new DateTime());
         $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+    }
+
+    /** @test */
+    public function it_works_when_starting_at_midnight_immutable()
+    {
+        $this->markTestIncomplete('Not supported in v1.x');
+
+        $openingHours = OpeningHours::create([
+            'monday' => ['00:00-16:00'],
+        ]);
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTimeImmutable());
+        $this->assertInstanceOf(DateTimeImmutable::class, $nextTimeOpen);
     }
 
     /** @test */

--- a/tests/TimeTest.php
+++ b/tests/TimeTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\OpeningHours\Test;
 
 use DateTime;
+use DateTimeImmutable;
 use Spatie\OpeningHours\Time;
 use PHPUnit\Framework\TestCase;
 use Spatie\OpeningHours\Exceptions\InvalidTimeString;
@@ -27,6 +28,10 @@ class TimeTest extends TestCase
     public function it_can_be_created_from_a_date_time_instance()
     {
         $dateTime = new DateTime('2016-09-27 16:00:00');
+
+        $this->assertEquals('16:00', (string) Time::fromDateTime($dateTime));
+
+        $dateTime = new DateTimeImmutable('2016-09-27 16:00:00');
 
         $this->assertEquals('16:00', (string) Time::fromDateTime($dateTime));
     }
@@ -108,6 +113,17 @@ class TimeTest extends TestCase
     public function it_should_not_mutate_passed_datetime()
     {
         $dateTime = new DateTime('2016-09-27 12:00:00');
+        $time = Time::fromString('15:00');
+        $this->assertEquals('2016-09-27 15:00:00', $time->toDateTime($dateTime)->format('Y-m-d H:i:s'));
+        $this->assertEquals('2016-09-27 12:00:00', $dateTime->format('Y-m-d H:i:s'));
+    }
+
+    /** @test */
+    public function it_should_not_mutate_passed_datetime_immutable()
+    {
+        $this->markTestIncomplete('Not supported in v1.x');
+
+        $dateTime = new DateTimeImmutable('2016-09-27 12:00:00');
         $time = Time::fromString('15:00');
         $this->assertEquals('2016-09-27 15:00:00', $time->toDateTime($dateTime)->format('Y-m-d H:i:s'));
         $this->assertEquals('2016-09-27 12:00:00', $dateTime->format('Y-m-d H:i:s'));


### PR DESCRIPTION
- Allow DateTimeImmutable where it's possible
- Fix #73: do not modify the passed datetime
- Allow multiple calls for nextClose/nextOpen
- Add unit tests and incomplete tests to show the current and ongoing support of immutability