### PR TITLE
Implement #43 adding createFromOverlappingRanges method

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,21 @@ $openingHours = OpeningHours::create([
 ]);
 ```
 
+#### `OpeningHours::mergeOverlappingRanges(array $schedule) : array`
+
+For safety sake, creating `OpeningHours` object with overlapping ranges will throw an exception. But you can explicitly merge them.
+
+``` php
+$ranges = [
+  'monday' => ['08:00-11:00', '10:00-12:00'],
+];
+$mergedRanges = OpeningHours::mergeOverlappingRanges($ranges); // monday become ['08:00-12:00']
+
+OpeningHours::create($mergedRanges);
+// Or use the following shortcut to create from ranges that possibly overlap:
+OpeningHours::createAndMergeOverlappingRanges($ranges);
+```
+
 Not all days are mandatory, if a day is missing, it will be set as closed.
 
 #### `OpeningHours::fill(array $data): Spatie\OpeningHours\OpeningHours`

--- a/src/Exceptions/InvalidTimeRangeList.php
+++ b/src/Exceptions/InvalidTimeRangeList.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\OpeningHours\Exceptions;
+
+class InvalidTimeRangeList extends Exception
+{
+    public static function create(): self
+    {
+        return new self('The given list is not a valid list of TimeRange instance containing at least one range.');
+    }
+}

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -91,7 +91,7 @@ class OpeningHours
      *
      * @return static
      */
-    public static function createFromOverlappingRanges(array $data)
+    public static function createAndMergeOverlappingRanges(array $data)
     {
         return static::create(static::mergeOverlappingRanges($data));
     }

--- a/src/TimeRange.php
+++ b/src/TimeRange.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\OpeningHours;
 
+use Spatie\OpeningHours\Exceptions\InvalidTimeRangeList;
 use Spatie\OpeningHours\Exceptions\InvalidTimeRangeString;
 
 class TimeRange
@@ -27,6 +28,35 @@ class TimeRange
         }
 
         return new self(Time::fromString($times[0]), Time::fromString($times[1]));
+    }
+
+    public static function fromList(array $ranges): self
+    {
+        if (count($ranges) === 0) {
+            throw InvalidTimeRangeList::create();
+        }
+
+        foreach ($ranges as $range) {
+            if (! ($range instanceof self)) {
+                throw InvalidTimeRangeList::create();
+            }
+        }
+
+        $start = $ranges[0]->start();
+        $end = $ranges[0]->end();
+
+        foreach (array_slice($ranges, 1) as $range) {
+            $rangeStart = $range->start();
+            if ($rangeStart->format('Gi') < $start->format('Gi')) {
+                $start = $rangeStart;
+            }
+            $rangeEnd = $range->end();
+            if ($rangeEnd->format('Gi') > $end->format('Gi')) {
+                $end = $rangeEnd;
+            }
+        }
+
+        return new self($start, $end);
     }
 
     public function start(): Time

--- a/tests/OpeningHoursFillTest.php
+++ b/tests/OpeningHoursFillTest.php
@@ -91,4 +91,40 @@ class OpeningHoursFillTest extends TestCase
             ],
         ]);
     }
+
+    /** @test */
+    public function it_should_merge_ranges_on_explicitly_create_from_overlapping_ranges()
+    {
+        $hours = OpeningHours::createFromOverlappingRanges([
+            'monday' => [
+                '08:00-12:00',
+                '11:30-13:30',
+                '13:00-18:00',
+            ],
+            'tuesday' => [
+                '08:00-12:00',
+                '11:30-13:30',
+                '15:00-18:00',
+                '16:00-17:00',
+                '19:00-20:00',
+                '20:00-21:00',
+            ],
+        ]);
+        $dump = [];
+        foreach (['monday', 'tuesday'] as $day) {
+            $dump[$day] = [];
+            foreach ($hours->forDay($day) as $range) {
+                $dump[$day][] = $range->format();
+            }
+        }
+
+        $this->assertSame([
+            '08:00-18:00',
+        ], $dump['monday']);
+        $this->assertSame([
+            '08:00-13:30',
+            '15:00-18:00',
+            '19:00-21:00',
+        ], $dump['tuesday']);
+    }
 }

--- a/tests/OpeningHoursFillTest.php
+++ b/tests/OpeningHoursFillTest.php
@@ -95,7 +95,7 @@ class OpeningHoursFillTest extends TestCase
     /** @test */
     public function it_should_merge_ranges_on_explicitly_create_from_overlapping_ranges()
     {
-        $hours = OpeningHours::createFromOverlappingRanges([
+        $hours = OpeningHours::createAndMergeOverlappingRanges([
             'monday' => [
                 '08:00-12:00',
                 '11:30-13:30',


### PR DESCRIPTION
Enable following possibilities to create OpeningHours object merging overlapping hours:
```php
OpeningHours::create(OpeningHours::mergeOverlappingRanges([...]));
// or 2-in-1:
OpeningHours::createFromOverlappingRanges([...]);
```