### PR TITLE
Add data support for next open hours

### DIFF
--- a/src/OpeningHoursForDay.php
+++ b/src/OpeningHoursForDay.php
@@ -93,12 +93,12 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
 
     protected function findNextOpenInWorkingHours(Time $time, TimeRange $timeRange)
     {
-        if ($timeRange->containsTime($time) && $next = next($timeRange) !== $timeRange) {
-            if (! $next instanceof Time) {
-                next($timeRange);
+        if ($timeRange->containsTime($time) && next($timeRange) !== $timeRange) {
+            if (! ($next = next($timeRange)) instanceof Time) {
+                return next($timeRange);
             }
 
-            return next($timeRange);
+            return $next;
         }
     }
 

--- a/src/OpeningHoursForDay.php
+++ b/src/OpeningHoursForDay.php
@@ -93,7 +93,11 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
 
     protected function findNextOpenInWorkingHours(Time $time, TimeRange $timeRange)
     {
-        if ($timeRange->containsTime($time) && next($timeRange) !== $timeRange) {
+        if ($timeRange->containsTime($time) && $next = next($timeRange) !== $timeRange) {
+            if (! $next instanceof Time) {
+                next($timeRange);
+            }
+        
             return next($timeRange);
         }
     }

--- a/src/OpeningHoursForDay.php
+++ b/src/OpeningHoursForDay.php
@@ -97,7 +97,7 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
             if (! $next instanceof Time) {
                 next($timeRange);
             }
-        
+
             return next($timeRange);
         }
     }

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -310,6 +310,7 @@ class OpeningHoursTest extends TestCase
         $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
         $this->assertEquals('2016-09-26 13:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
     }
+
     /** @test */
     public function it_can_determine_next_open_hours_from_edges_time()
     {

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -280,7 +280,13 @@ class OpeningHoursTest extends TestCase
     public function it_can_determine_next_open_hours_from_edges_time()
     {
         $openingHours = OpeningHours::create([
-            'monday' => ['09:00-11:00', '13:00-19:00'],
+            'monday' => [
+                [
+                    'hours' => '09:00-11:00',
+                    'data' => ['foobar'],
+                ],
+                '13:00-19:00',
+            ],
             'tuesday' => ['09:00-11:00', '13:00-19:00'],
         ]);
 

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -310,18 +310,11 @@ class OpeningHoursTest extends TestCase
         $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
         $this->assertEquals('2016-09-26 13:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
     }
-
     /** @test */
     public function it_can_determine_next_open_hours_from_edges_time()
     {
         $openingHours = OpeningHours::create([
-            'monday' => [
-                [
-                    'hours' => '09:00-11:00',
-                    'data' => ['foobar'],
-                ],
-                '13:00-19:00',
-            ],
+            'monday' => ['09:00-11:00', '13:00-19:00'],
             'tuesday' => ['09:00-11:00', '13:00-19:00'],
         ]);
 
@@ -359,6 +352,110 @@ class OpeningHoursTest extends TestCase
 
         $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
         $this->assertEquals('2016-09-27 09:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+    }
+
+    /** @test */
+    public function it_can_determine_next_open_hours_from_mixed_structures()
+    {
+        $openingHours = OpeningHours::create([
+            'monday' => [
+                [
+                    'hours' => '09:00-11:00',
+                    'data' => ['foobar'],
+                ],
+                '13:00-19:00',
+            ],
+        ]);
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2019-02-11 00:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2019-02-11 09:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+
+        $nextTimeClose = $openingHours->nextClose(new DateTime('2019-02-11 00:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeClose);
+        $this->assertEquals('2019-02-11 11:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2019-02-11 09:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2019-02-11 13:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+
+        $nextTimeClose = $openingHours->nextClose(new DateTime('2019-02-11 09:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeClose);
+        $this->assertEquals('2019-02-11 11:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2019-02-11 10:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2019-02-11 13:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+
+        $nextTimeClose = $openingHours->nextClose(new DateTime('2019-02-11 10:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeClose);
+        $this->assertEquals('2019-02-11 11:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2019-02-11 11:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2019-02-11 13:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+
+        $nextTimeClose = $openingHours->nextClose(new DateTime('2019-02-11 11:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeClose);
+        $this->assertEquals('2019-02-11 19:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2019-02-11 12:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2019-02-11 13:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+
+        $nextTimeClose = $openingHours->nextClose(new DateTime('2019-02-11 12:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeClose);
+        $this->assertEquals('2019-02-11 19:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2019-02-11 13:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2019-02-18 09:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+
+        $nextTimeClose = $openingHours->nextClose(new DateTime('2019-02-11 13:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeClose);
+        $this->assertEquals('2019-02-11 19:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2019-02-11 15:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2019-02-18 09:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+
+        $nextTimeClose = $openingHours->nextClose(new DateTime('2019-02-11 15:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeClose);
+        $this->assertEquals('2019-02-11 19:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2019-02-11 19:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2019-02-18 09:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+
+        $nextTimeClose = $openingHours->nextClose(new DateTime('2019-02-11 19:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeClose);
+        $this->assertEquals('2019-02-18 11:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
+
+        $nextTimeOpen = $openingHours->nextOpen(new DateTime('2019-02-11 21:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeOpen);
+        $this->assertEquals('2019-02-18 09:00:00', $nextTimeOpen->format('Y-m-d H:i:s'));
+
+        $nextTimeClose = $openingHours->nextClose(new DateTime('2019-02-11 21:00:00'));
+
+        $this->assertInstanceOf(DateTime::class, $nextTimeClose);
+        $this->assertEquals('2019-02-18 11:00:00', $nextTimeClose->format('Y-m-d H:i:s'));
     }
 
     /** @test */


### PR DESCRIPTION
This PR fixes `Call to a member function toDateTime() on array` error when trying to call `nextOpen` method with:
```php
'monday' => [
    [
        'hours' => '09:00-11:00',
        'data' => ['foobar'],
    ],
    '13:00-19:00',
],
```