### PR TITLE
Fix #115 return 24:00 when Time::fromString('24:00') is casted to string

### DIFF
--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -6,12 +6,12 @@ use DateTime;
 use DateTimeZone;
 use DateTimeImmutable;
 use DateTimeInterface;
-use Spatie\OpeningHours\Exceptions\MaximumLimitExceeded;
 use Spatie\OpeningHours\Helpers\Arr;
 use Spatie\OpeningHours\Helpers\DataTrait;
 use Spatie\OpeningHours\Exceptions\Exception;
 use Spatie\OpeningHours\Exceptions\InvalidDate;
 use Spatie\OpeningHours\Exceptions\InvalidDayName;
+use Spatie\OpeningHours\Exceptions\MaximumLimitExceeded;
 
 class OpeningHours
 {
@@ -452,7 +452,7 @@ class OpeningHours
             return;
         }
 
-        if (!$this->dayLimit) {
+        if (! $this->dayLimit) {
             $this->dayLimit = 366;
         }
 

--- a/src/Time.php
+++ b/src/Time.php
@@ -100,6 +100,10 @@ class Time
 
     public function format(string $format = 'H:i'): string
     {
+        if ($format === 'H:i' && $this->hours === 24 && $this->minutes === 0) {
+            return '24:00';
+        }
+
         return $this->toDateTime()->format($format);
     }
 

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -6,8 +6,8 @@ use DateTime;
 use DateTimeZone;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
-use Spatie\OpeningHours\Exceptions\MaximumLimitExceeded;
 use Spatie\OpeningHours\OpeningHours;
+use Spatie\OpeningHours\Exceptions\MaximumLimitExceeded;
 
 class OpeningHoursTest extends TestCase
 {

--- a/tests/TimeTest.php
+++ b/tests/TimeTest.php
@@ -13,7 +13,9 @@ class TimeTest extends TestCase
     /** @test */
     public function it_can_be_created_from_a_string()
     {
-        $this->assertEquals('16:00', (string) Time::fromString('16:00'));
+        $this->assertEquals('00:00', (string) Time::fromString('00:00'));
+        $this->assertEquals('16:32', (string) Time::fromString('16:32'));
+        $this->assertEquals('24:00', (string) Time::fromString('24:00'));
     }
 
     /** @test */


### PR DESCRIPTION
This allows de facto `createAndMergeOverlappingRanges` to have `24:00` in its passed ranges.