### PR TITLE
Fix #119 - use TimeRange comparison functions

### DIFF
--- a/src/TimeRange.php
+++ b/src/TimeRange.php
@@ -83,11 +83,11 @@ class TimeRange
 
         foreach (array_slice($ranges, 1) as $range) {
             $rangeStart = $range->start();
-            if ($rangeStart->format('Gi') < $start->format('Gi')) {
+            if ($rangeStart->isBefore($start)) {
                 $start = $rangeStart;
             }
             $rangeEnd = $range->end();
-            if ($rangeEnd->format('Gi') > $end->format('Gi')) {
+            if ($rangeEnd->isAfter($end)) {
                 $end = $rangeEnd;
             }
         }

--- a/tests/OpeningHoursFillTest.php
+++ b/tests/OpeningHoursFillTest.php
@@ -312,4 +312,23 @@ class OpeningHoursFillTest extends TestCase
             '19:00-21:00',
         ], $dump['tuesday']);
     }
+
+    /** @test */
+    public function it_should_merge_ranges_including_explicit_24_00()
+    {
+        $hours = OpeningHours::createAndMergeOverlappingRanges([
+            'monday' => [
+                '08:00-12:00',
+                '12:00-24:00',
+            ],
+        ]);
+        $dump = [];
+        foreach ($hours->forDay('monday') as $range) {
+            $dump[] = $range->format();
+        }
+
+        $this->assertSame([
+            '08:00-24:00',
+        ], $dump);
+    }
 }


### PR DESCRIPTION
Use TimeRange::isBefore() and TimeRange::isAfter() to compare times. This ensures that 24:00 doesn't get accidentally formatted as 000.

Fixes #119