### PR TITLE
throw exception instead of fail if duplicate exception date is used

### DIFF
--- a/src/TimeRange.php
+++ b/src/TimeRange.php
@@ -63,6 +63,9 @@ class TimeRange
 
     public static function fromDefinition($value): self
     {
+        if (!$value) {
+            throw new Exception('Duplicate or overlapping date or hours');
+        }
         return is_array($value) ? static::fromArray($value) : static::fromString($value);
     }
 


### PR DESCRIPTION
In Laravel, I am using a "HoursOfOperation" model that implements opening-hours. Adding to the API, I noticed that if 

The model is populated by an API. if a duplicate exception date is added (I.E. listing exception date [12-25] twice, opening-hours object instantiation fails with:

"Argument 1 passed to Spatie\\OpeningHours\\TimeRange::fromString() must be of the type string, null given, called in /home/vagrant/code/ib_laravel/vendor/spatie/opening-hours/src/TimeRange.php on line 66"

Adding this exception allows me to catch that.