### PR TITLE
Compatibility with PHP 8.1

### DIFF
--- a/src/OpeningHoursForDay.php
+++ b/src/OpeningHoursForDay.php
@@ -80,8 +80,6 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
         foreach (($reverse ? array_reverse($this->openingHours) : $this->openingHours) as $timeRange) {
             foreach ($filters as $filter) {
                 if ($result = $filter($timeRange)) {
-                    reset($timeRange);
-
                     return $result;
                 }
             }
@@ -216,16 +214,19 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
         return isset($this->openingHours[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->openingHours[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw NonMutableOffsets::forClass(static::class);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->openingHours[$offset]);
@@ -236,7 +237,7 @@ class OpeningHoursForDay implements ArrayAccess, Countable, IteratorAggregate
         return count($this->openingHours);
     }
 
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->openingHours);
     }


### PR DESCRIPTION
Fixes the following deprecation notices:

- > Return type of Spatie\OpeningHours\OpeningHoursForDay::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
- > Return type of Spatie\OpeningHours\OpeningHoursForDay::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
- > Return type of Spatie\OpeningHours\OpeningHoursForDay::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
- > reset(): Calling reset() on an object is deprecated

Regarding the last bullet point: what was the rationale behind calling `reset()` on `TimeRange`? What was that supposed to do?