### PR TITLE
Fixed edge case - previouslyClose returning the wrong result

### DIFF
--- a/src/Helpers/RangeFinder.php
+++ b/src/Helpers/RangeFinder.php
@@ -82,7 +82,7 @@ trait RangeFinder
     {
         $end = $timeRange->end();
 
-        if ($end->isBefore($time)) {
+        if ($end->isSame($time) || $end->isBefore($time)) {
             return $end;
         }
     }

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -430,6 +430,10 @@ class OpeningHoursTest extends TestCase
         $friday = new DateTimeImmutable('2019-02-08 02:00:00');
         $this->assertSame('2019-02-07 00:00:00', $openingHours->previousClose($friday)->format('Y-m-d H:i:s'));
         $this->assertSame('2019-02-08 00:00:00', $openingHours->previousOpen($friday)->format('Y-m-d H:i:s'));
+
+        $friday = new DateTimeImmutable('2019-02-08 03:00:00');
+        $this->assertSame('2019-02-08 03:00:00', $openingHours->previousClose($friday)->format('Y-m-d H:i:s'));
+        $this->assertFalse($openingHours->currentOpenRange($friday));
     }
 
     /** @test */


### PR DESCRIPTION
In the test `it_can_handle_consecutive_open_hours` I inserted the following:

```
        $friday = new DateTimeImmutable('2019-02-08 03:00:59');
        $this->assertSame('2019-02-08 03:00:00', $openingHours->previousClose($friday)->format('Y-m-d H:i:s'));
```
Although the closing was 59 seconds ago, this fails as it returns '2019-02-07 00:00:00' as the previous close date/time.

This is fixed by adding a new condition to `findPreviousCloseInWorkingHours`:

```
        if ($end->isSame($time) || $end->isBefore($time)) {
```
The new test would be:
```
        $friday = new DateTimeImmutable('2019-02-08 03:00:00');
        $this->assertSame('2019-02-08 03:00:00', $openingHours->previousClose($friday)->format('Y-m-d H:i:s'));
```

The only argument is whether 03:00:00 should return the same as the previous close, or wait until 03:00:01.

My argument is that is should return 2019-02-08 03:00:00 as the previous close exactly at 03:00:00, as this means it is now closed.

Also note that at 2019-02-08 03:00:00, currentOpenRange() will return false, which means it just closed. This increases the argument for previousClose to return 2019-02-08 03:00:00. I also added a test line to ensure the currentOpenRange is returning false as expected.