### PR TITLE
fixed typo on timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ $openingHours = OpeningHours::create([
     'monday' => ['09:00-12:00', '13:00-18:00'],
     'timezone' => [
         'input' => 'America/New_York',
-        'output' => 'Europe/Olso',
+        'output' => 'Europe/Oslo',
     ],
 ]);
 ```


### PR DESCRIPTION
Corrected the timezone in the documentation
From `'timezone' => [
        'input' => 'America/New_York',
        'output' => 'Europe/Olso',
    ],` 
To `'timezone' => [
        'input' => 'America/New_York',
        'output' => 'Europe/Oslo',
    ],`