### PR TITLE
Improve createFromStructuredData()

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,31 @@ Checks if the business is closed right now.
 $openingHours->isClosed();
 ```
 
+#### `OpeningHours::isAlwaysOpen(): bool`
+
+Checks if the business is open 24/7, has no exceptions and no filters.
+
+```php
+if ($openingHours->isAlwaysOpen()) {
+    echo 'This business is open all day long every day.';
+}
+```
+
+#### `OpeningHours::isAlwaysClosed(): bool`
+
+Checks if the business is never open, has no exceptions and no filters.
+
+`OpeningHours` accept empty array or list with every week day empty with no prejudices.
+
+If it's not a valid state in your domain, you should use this method to throw an exception
+or show an error.
+
+```php
+if ($openingHours->isAlwaysClosed()) {
+    throw new RuntimeException('Opening hours missing');
+}
+```
+
 #### `OpeningHours::nextOpen`
 
 ```php

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -128,7 +128,11 @@ class OpeningHours
         string|DateTimeZone|null $outputTimezone = null,
     ): self {
         return new static(
-            OpeningHoursSpecificationParser::create($structuredData)->getOpeningHours(),
+            array_merge(
+                // https://schema.org/OpeningHoursSpecification allows overflow by default
+                ['overflow' => true],
+                OpeningHoursSpecificationParser::create($structuredData)->getOpeningHours(),
+            ),
             $timezone,
             $outputTimezone,
         );
@@ -936,7 +940,7 @@ class OpeningHours
     public function every(callable $callback): bool
     {
         return $this->filter(
-            static fn (OpeningHoursForDay $day) => !$callback($day),
+            static fn (OpeningHoursForDay $day) => ! $callback($day),
         ) === [];
     }
 

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -128,9 +128,11 @@ class OpeningHours
         string|DateTimeZone|null $timezone = null,
         string|DateTimeZone|null $outputTimezone = null,
     ): self {
-        $parser = new OpeningHoursSpecificationParser($structuredData);
-
-        return new static($parser->getOpeningHours(), $timezone, $outputTimezone);
+        return new static(
+            OpeningHoursSpecificationParser::create($structuredData)->getOpeningHours(),
+            $timezone,
+            $outputTimezone,
+        );
     }
 
     /**

--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -20,7 +20,6 @@ use Spatie\OpeningHours\Helpers\Arr;
 use Spatie\OpeningHours\Helpers\DataTrait;
 use Spatie\OpeningHours\Helpers\DateTimeCopier;
 use Spatie\OpeningHours\Helpers\DiffTrait;
-use ValueError;
 
 class OpeningHours
 {
@@ -215,7 +214,7 @@ class OpeningHours
             static::create($data);
 
             return true;
-        } catch (Exception|ValueError) {
+        } catch (Exception) {
             return false;
         }
     }
@@ -893,6 +892,11 @@ class OpeningHours
         return $date;
     }
 
+    /**
+     * Returns opening hours for the days that match a given condition as an array.
+     *
+     * @return OpeningHoursForDay[]
+     */
     public function filter(callable $callback): array
     {
         return Arr::filter($this->openingHours, $callback);
@@ -908,6 +912,11 @@ class OpeningHours
         return Arr::flatMap($this->openingHours, $callback);
     }
 
+    /**
+     * Returns opening hours for the exceptions that match a given condition as an array.
+     *
+     * @return OpeningHoursForDay[]
+     */
     public function filterExceptions(callable $callback): array
     {
         return Arr::filter($this->exceptions, $callback);
@@ -921,6 +930,14 @@ class OpeningHours
     public function flatMapExceptions(callable $callback): array
     {
         return Arr::flatMap($this->exceptions, $callback);
+    }
+
+    /** Checks that opening hours for every day of the week matches a given condition */
+    public function every(callable $callback): bool
+    {
+        return $this->filter(
+            static fn (OpeningHoursForDay $day) => !$callback($day),
+        ) === [];
     }
 
     public function asStructuredData(
@@ -965,6 +982,20 @@ class OpeningHours
         );
 
         return array_merge($regularHours, $exceptions);
+    }
+
+    public function isAlwaysClosed(): bool
+    {
+        return $this->exceptions === [] && $this->filters === [] && $this->every(
+            static fn (OpeningHoursForDay $day) => $day->isEmpty(),
+        );
+    }
+
+    public function isAlwaysOpen(): bool
+    {
+        return $this->exceptions === [] && $this->filters === [] && $this->every(
+            static fn (OpeningHoursForDay $day) => ((string) $day) === '00:00-24:00',
+        );
     }
 
     private static function filterHours(array $data, array $excludedKeys): Generator

--- a/src/OpeningHoursSpecificationParser.php
+++ b/src/OpeningHoursSpecificationParser.php
@@ -11,29 +11,8 @@ final class OpeningHoursSpecificationParser
 {
     private array $openingHours = [];
 
-    public function __construct(array|string|null $openingHoursSpecification)
+    private function __construct(array $openingHoursSpecification)
     {
-        if (is_string($openingHoursSpecification)) {
-            try {
-                $openingHoursSpecification = json_decode(
-                    $openingHoursSpecification,
-                    true,
-                    flags: JSON_THROW_ON_ERROR,
-                );
-            } catch (JsonException $e) {
-                throw new InvalidOpeningHoursSpecification(
-                    'Invalid https://schema.org/OpeningHoursSpecification JSON',
-                    previous: $e,
-                );
-            }
-        }
-
-        if (! is_array($openingHoursSpecification) || $openingHoursSpecification === []) {
-            throw new InvalidOpeningHoursSpecification(
-                'Invalid https://schema.org/OpeningHoursSpecification structured data',
-            );
-        }
-
         foreach ($openingHoursSpecification as $openingHoursSpecificationItem) {
             if (isset($openingHoursSpecificationItem['dayOfWeek'])) {
                 /*
@@ -81,6 +60,34 @@ final class OpeningHoursSpecificationParser
                 );
             }
         }
+    }
+
+    public static function createFromArray(array $openingHoursSpecification): self
+    {
+        return new self($openingHoursSpecification);
+    }
+
+    public static function createFromString(string $openingHoursSpecification): self
+    {
+        try {
+            return self::createFromArray(json_decode(
+                $openingHoursSpecification,
+                true,
+                flags: JSON_THROW_ON_ERROR,
+            ));
+        } catch (JsonException $e) {
+            throw new InvalidOpeningHoursSpecification(
+                'Invalid https://schema.org/OpeningHoursSpecification JSON',
+                previous: $e,
+            );
+        }
+    }
+
+    public static function create(array|string $openingHoursSpecification): self
+    {
+        return is_string($openingHoursSpecification)
+            ? self::createFromString($openingHoursSpecification)
+            : self::createFromArray($openingHoursSpecification);
     }
 
     public function getOpeningHours(): array

--- a/src/OpeningHoursSpecificationParser.php
+++ b/src/OpeningHoursSpecificationParser.php
@@ -61,7 +61,7 @@ final class OpeningHoursSpecificationParser
     }
 
     /**
-     * Regular opening hours
+     * Regular opening hours.
      */
     private function addDaysOfWeek(
         array $dayOfWeek,

--- a/tests/OpeningHoursFillTest.php
+++ b/tests/OpeningHoursFillTest.php
@@ -11,7 +11,6 @@ use Spatie\OpeningHours\Exceptions\InvalidDayName;
 use Spatie\OpeningHours\OpeningHours;
 use Spatie\OpeningHours\OpeningHoursForDay;
 use Spatie\OpeningHours\TimeRange;
-use ValueError;
 
 class OpeningHoursFillTest extends TestCase
 {

--- a/tests/OpeningHoursSpecificationParserTest.php
+++ b/tests/OpeningHoursSpecificationParserTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Spatie\OpeningHours\Test;
 
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
+use Spatie\OpeningHours\Day;
+use Spatie\OpeningHours\Exceptions\InvalidOpeningHoursSpecification;
 use Spatie\OpeningHours\OpeningHours;
 
 class OpeningHoursSpecificationParserTest extends TestCase
@@ -68,7 +71,7 @@ class OpeningHoursSpecificationParserTest extends TestCase
             ]
             JSON;
 
-        $openingHours = OpeningHours::createFromStructuredData(json_decode($openingHoursSpecs, true));
+        $openingHours = OpeningHours::createFromStructuredData($openingHoursSpecs);
         $this->assertInstanceOf(OpeningHours::class, $openingHours);
 
         $this->assertCount(2, $openingHours->forDay('monday'));
@@ -99,5 +102,209 @@ class OpeningHoursSpecificationParserTest extends TestCase
             $openingHours->isOpenAt(new \DateTime('2023-12-24 10:00')),
             'Opened on 2023 Sunday before Christmas day',
         );
+    }
+
+    public function testEmptySpecs(): void
+    {
+        $openingHours = OpeningHours::createFromStructuredData([]);
+
+        $this->assertTrue($openingHours->isAlwaysClosed());
+    }
+
+    public function testH24Specs(): void
+    {
+        $openingHours = OpeningHours::createFromStructuredData([
+            [
+                'opens' => '00:00',
+                'closes' => '23:59',
+                'dayOfWeek' => [
+                    'Monday',
+                    'Tuesday',
+                    'Wednesday',
+                    'Thursday',
+                    'Friday',
+                ],
+            ],
+        ]);
+
+        $this->assertTrue(
+            $openingHours->isOpenAt(new DateTimeImmutable('2023-11-27 23:59:34')),
+            'As per specs, 23:59 is assumed to mean until end of day',
+        );
+        $this->assertFalse(
+            $openingHours->isOpenAt(new DateTimeImmutable('2023-11-25 23:59:34')),
+            'Saturday and Sunday not specified means they are closed',
+        );
+        $this->assertFalse(
+            $openingHours->isAlwaysOpen(),
+            'Saturday and Sunday not specified means they are closed',
+        );
+
+        $openingHours = OpeningHours::createFromStructuredData([
+            [
+                'opens' => '00:00',
+                'closes' => '23:59',
+                'dayOfWeek' => [
+                    'Monday',
+                    'Tuesday',
+                    'Wednesday',
+                    'Thursday',
+                    'Friday',
+                    'Saturday',
+                    'Sunday',
+                ],
+            ],
+        ]);
+
+        $this->assertTrue(
+            $openingHours->isAlwaysOpen(),
+            'As per specs, 23:59 is assumed to mean until end of day',
+        );
+    }
+
+    public function testClosedDay(): void
+    {
+        $openingHours = OpeningHours::createFromStructuredData([
+            ['dayOfWeek' => 'Monday'],
+        ]);
+
+        $this->assertSame('', (string) $openingHours->forDay(Day::MONDAY));
+    }
+
+    public function testInvalidJson(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid https://schema.org/OpeningHoursSpecification JSON',
+        ));
+
+        OpeningHours::createFromStructuredData('{');
+    }
+
+    public function testInvalidDayOfWeek(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid openingHoursSpecification item at index 1: Property dayOfWeek must be a string or an array of strings',
+        ));
+
+        OpeningHours::createFromStructuredData([
+            ['dayOfWeek' => []],
+            ['dayOfWeek' => true],
+        ]);
+    }
+
+    public function testInvalidDayType(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid openingHoursSpecification item at index 0: Invalid https://schema.org/OpeningHoursSpecification dayOfWeek',
+        ));
+
+        OpeningHours::createFromStructuredData([
+            ['dayOfWeek' => [true]],
+        ]);
+    }
+
+    public function testInvalidDayName(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid openingHoursSpecification item at index 0: Invalid https://schema.org Day specification',
+        ));
+
+        OpeningHours::createFromStructuredData([
+            ['dayOfWeek' => ['Wedmonday']],
+        ]);
+    }
+
+    public function testUnsupportedPublicHolidays(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid openingHoursSpecification item at index 0: PublicHolidays not supported',
+        ));
+
+        OpeningHours::createFromStructuredData([
+            ['dayOfWeek' => 'PublicHolidays'],
+        ]);
+    }
+
+    public function testInvalidValidPair(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid openingHoursSpecification item at index 0: Contains neither dayOfWeek nor validFrom and validThrough dates',
+        ));
+
+        OpeningHours::createFromStructuredData([
+            ['validFrom' => '2023-11-25'],
+        ]);
+    }
+
+    public function testInvalidOpens(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid openingHoursSpecification item at index 0: Invalid opens hour',
+        ));
+
+        OpeningHours::createFromStructuredData([
+            [
+                'dayOfWeek' => 'Monday',
+                'opens' => 'noon',
+                'closes' => '14:00',
+            ],
+        ]);
+    }
+
+    public function testInvalidCloses(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid openingHoursSpecification item at index 0: Invalid closes hour',
+        ));
+
+        OpeningHours::createFromStructuredData([
+            [
+                'dayOfWeek' => 'Monday',
+                'opens' => '10:00',
+                'closes' => 'noon',
+            ],
+        ]);
+    }
+
+    public function testClosesOnly(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid openingHoursSpecification item at index 0: Property opens and closes must be both null or both string',
+        ));
+
+        OpeningHours::createFromStructuredData([
+            [
+                'dayOfWeek' => 'Monday',
+                'closes' => '10:00',
+            ],
+        ]);
+    }
+
+    public function testInvalidValidFrom(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid openingHoursSpecification item at index 0: Invalid validFrom date',
+        ));
+
+        OpeningHours::createFromStructuredData([
+            [
+                'validFrom' => '11/11/2023',
+                'validThrough' => '2023-11-25',
+            ],
+        ]);
+    }
+
+    public function testInvalidValidThrough(): void
+    {
+        self::expectExceptionObject(new InvalidOpeningHoursSpecification(
+            'Invalid openingHoursSpecification item at index 0: Invalid validThrough date',
+        ));
+
+        OpeningHours::createFromStructuredData([
+            [
+                'validFrom' => '2023-11-11',
+                'validThrough' => '25/11/20235',
+            ],
+        ]);
     }
 }

--- a/tests/OpeningHoursSpecificationParserTest.php
+++ b/tests/OpeningHoursSpecificationParserTest.php
@@ -111,6 +111,23 @@ class OpeningHoursSpecificationParserTest extends TestCase
         $this->assertTrue($openingHours->isAlwaysClosed());
     }
 
+    public function testRangeOverNight(): void
+    {
+        $openingHours = OpeningHours::createFromStructuredData([
+            [
+                'dayOfWeek' => 'Monday',
+                'opens' => '18:00',
+                'closes' => '02:00',
+            ],
+        ]);
+
+        $this->assertTrue($openingHours->isClosedAt(new DateTimeImmutable('2023-11-27 17:50')));
+        $this->assertTrue($openingHours->isOpenAt(new DateTimeImmutable('2023-11-27 23:55')));
+        $this->assertTrue($openingHours->isOpenAt(new DateTimeImmutable('2023-11-27 23:59:59.99')));
+        $this->assertTrue($openingHours->isOpenAt(new DateTimeImmutable('2023-11-28 01:50')));
+        $this->assertTrue($openingHours->isClosedAt(new DateTimeImmutable('2023-11-28 19:00')));
+    }
+
     public function testH24Specs(): void
     {
         $openingHours = OpeningHours::createFromStructuredData([

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -957,7 +957,8 @@ class OpeningHoursTest extends TestCase
     /** @test */
     public function it_can_use_day_enum()
     {
-        $openingHours = new class () extends OpeningHours {
+        $openingHours = new class () extends OpeningHours
+        {
             public readonly array $days;
 
             public function __construct()

--- a/tests/OpeningHoursTest.php
+++ b/tests/OpeningHoursTest.php
@@ -957,7 +957,7 @@ class OpeningHoursTest extends TestCase
     /** @test */
     public function it_can_use_day_enum()
     {
-        $openingHours = new class () extends OpeningHours
+        $openingHours = new class extends OpeningHours
         {
             public readonly array $days;
 


### PR DESCRIPTION
- Allow empty array for createFromStructuredData() (as specs allow it)
- Make OpeningHoursSpecificationParser constructor private and add separated named constructors
- Add details in exceptions to know what is the issue precisely and which item is incorrect
- Accept empty array as per specs for structured-data
- Add utils to know if opening-hours are always open/closed
- Add OpeningHours::every() method
- Make 23:59 short for 24:00 in createFromStructuredData (the way to represent 24h/24 for OpeningHours)
- Make range where closes < opens span over night (as per specs)