### PR TITLE
Fix Time comparison to ignore metadata and date context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `opening-hours` will be documented in this file
 ## 4.0.0 - upcoming
 
 - Replace `getData()` with readonly property `->data`
+- Fix `Time::isBefore()` and `Time::isAfter()` comparing metadata and date context instead of clock time only
 
 ## 3.0.0 - 2023-11-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 All notable changes to `opening-hours` will be documented in this file
 
-## 4.0.0 - upcoming
+## 4.0.1 - 2026-07-09
+
+- Fix `Time::isBefore()` and `Time::isAfter()` comparing metadata and date context instead of clock time only
+
+## 4.0.0 - 2024-06-26
 
 - Replace `getData()` with readonly property `->data`
-- Fix `Time::isBefore()` and `Time::isAfter()` comparing metadata and date context instead of clock time only
 
 ## 3.0.0 - 2023-11-12
 

--- a/src/Time.php
+++ b/src/Time.php
@@ -57,17 +57,27 @@ readonly class Time implements TimeDataContainer
 
     public function isSame(self $time): bool
     {
-        return $this->hours === $time->hours && $this->minutes === $time->minutes;
+        return $this->compareClockTime($time) === 0;
     }
 
     public function isAfter(self $time): bool
     {
-        return $this > $time;
+        return $this->compareClockTime($time) > 0;
     }
 
     public function isBefore(self $time): bool
     {
-        return $this < $time;
+        return $this->compareClockTime($time) < 0;
+    }
+
+    private function compareClockTime(self $time): int
+    {
+        return $this->clockMinutes() <=> $time->clockMinutes();
+    }
+
+    private function clockMinutes(): int
+    {
+        return $this->hours * 60 + $this->minutes;
     }
 
     public function isSameOrAfter(self $time): bool

--- a/src/Time.php
+++ b/src/Time.php
@@ -57,32 +57,27 @@ readonly class Time implements TimeDataContainer
 
     public function isSame(self $time): bool
     {
-        return $this->compareClockTime($time) === 0;
+        return $this->toDateTime() == $time->toDateTime();
     }
 
     public function isAfter(self $time): bool
     {
-        return $this->compareClockTime($time) > 0;
+        return $this->toDateTime() > $time->toDateTime();
     }
 
     public function isBefore(self $time): bool
     {
-        return $this->compareClockTime($time) < 0;
-    }
-
-    private function compareClockTime(self $time): int
-    {
-        return $this->clockMinutes() <=> $time->clockMinutes();
-    }
-
-    private function clockMinutes(): int
-    {
-        return $this->hours * 60 + $this->minutes;
+        return $this->toDateTime() < $time->toDateTime();
     }
 
     public function isSameOrAfter(self $time): bool
     {
-        return $this->isSame($time) || $this->isAfter($time);
+        return $this->toDateTime() >= $time->toDateTime();
+    }
+
+    public function isSameOrBefore(self $time): bool
+    {
+        return $this->toDateTime() <= $time->toDateTime();
     }
 
     public function diff(self $time): DateInterval

--- a/tests/TimeTest.php
+++ b/tests/TimeTest.php
@@ -81,6 +81,7 @@ class TimeTest extends TestCase
         $this->assertFalse($timeWithDataA->isBefore($timeWithDataB));
         $this->assertFalse($timeWithDataA->isAfter($timeWithDataB));
         $this->assertTrue($timeWithDataA->isSameOrAfter($timeWithDataB));
+        $this->assertTrue($timeWithDataA->isSameOrBefore($timeWithDataB));
     }
 
     #[Test]
@@ -93,6 +94,7 @@ class TimeTest extends TestCase
         $this->assertFalse($timeWithDateA->isBefore($timeWithDateB));
         $this->assertFalse($timeWithDateA->isAfter($timeWithDateB));
         $this->assertTrue($timeWithDateA->isSameOrAfter($timeWithDateB));
+        $this->assertTrue($timeWithDateA->isSameOrBefore($timeWithDateB));
     }
 
     #[Test]

--- a/tests/TimeTest.php
+++ b/tests/TimeTest.php
@@ -72,6 +72,44 @@ class TimeTest extends TestCase
     }
 
     #[Test]
+    public function it_ignores_metadata_when_comparing_times()
+    {
+        $timeWithDataA = Time::fromString('09:00', data: ['label' => 'morning']);
+        $timeWithDataB = Time::fromString('09:00', data: ['label' => 'opening']);
+
+        $this->assertTrue($timeWithDataA->isSame($timeWithDataB));
+        $this->assertFalse($timeWithDataA->isBefore($timeWithDataB));
+        $this->assertFalse($timeWithDataA->isAfter($timeWithDataB));
+        $this->assertTrue($timeWithDataA->isSameOrAfter($timeWithDataB));
+    }
+
+    #[Test]
+    public function it_ignores_date_context_when_comparing_times()
+    {
+        $timeWithDateA = Time::fromString('09:00', date: new DateTimeImmutable('2020-01-01'));
+        $timeWithDateB = Time::fromString('09:00', date: new DateTimeImmutable('2025-06-15'));
+
+        $this->assertTrue($timeWithDateA->isSame($timeWithDateB));
+        $this->assertFalse($timeWithDateA->isBefore($timeWithDateB));
+        $this->assertFalse($timeWithDateA->isAfter($timeWithDateB));
+        $this->assertTrue($timeWithDateA->isSameOrAfter($timeWithDateB));
+    }
+
+    #[Test]
+    public function it_compares_end_of_day_midnight_correctly()
+    {
+        $endOfDay = Time::fromString('24:00');
+        $lastMinute = Time::fromString('23:59');
+        $midnight = Time::fromString('00:00');
+
+        $this->assertTrue($endOfDay->isAfter($lastMinute));
+        $this->assertFalse($endOfDay->isSame($midnight));
+        $this->assertFalse($endOfDay->isBefore($midnight));
+        $this->assertTrue($endOfDay->isAfter($midnight));
+        $this->assertFalse($lastMinute->isAfter($endOfDay));
+    }
+
+    #[Test]
     public function it_can_determine_that_its_before_another_time()
     {
         $this->assertTrue(Time::fromString('09:00')->isBefore(Time::fromString('10:00')));


### PR DESCRIPTION
`Time::isBefore()` and `Time::isAfter()` were using PHP object comparison, which is quite brittle. It looked at the `$data` and `$date` fields. Two times with the same hours and minutes could be ordered differently just because they had different metadata attached.

This fix makes it so that we compare only the clock time (hours and minutes), matching what `isSame()` already did.

## Bug reproduction

Before the fix, these failed:

- `Time::fromString('09:00', data: ['label' => 'morning'])` vs `Time::fromString('09:00', data: ['label' => 'opening'])`: same clock time, but one could be considered before/after the other
- Same clock time with different `date` reference points was also incorrectly ordered

## Changes

- Compare times by total minutes (`hours * 60 + minutes`) instead of object comparison.
- Route `isSame()`, `isBefore()`, and `isAfter()` through this same comparison path.
- Added regression tests for metadata/date-insensitive comparison and `24:00` ordering.